### PR TITLE
Use Guid.NewGuid for workflow definitions and add builder ID override

### DIFF
--- a/src/GvatarWorkflow/Entities/Interfaces/IWorkflowDefinitionBuilder.cs
+++ b/src/GvatarWorkflow/Entities/Interfaces/IWorkflowDefinitionBuilder.cs
@@ -6,5 +6,6 @@ public interface IWorkflowDefinitionBuilder
     public IWorkflowDefinitionBuilder AddDescription(string description);
     public IWorkflowDefinitionBuilder AddVersion(int version);
     public IWorkflowDefinitionBuilder AddName(string name);
+    public IWorkflowDefinitionBuilder AddId(Guid id);
     public WorkflowDefinition Build();
 }

--- a/src/GvatarWorkflow/Entities/WorkflowDefinition.cs
+++ b/src/GvatarWorkflow/Entities/WorkflowDefinition.cs
@@ -14,6 +14,7 @@ public class WorkflowDefinition
 public class WorkflowDefinitionBuilder : IWorkflowDefinitionBuilder
 {
     private readonly WorkflowDefinition _workflowDefinition = new();
+    private Guid? _workflowId;
 
     public IWorkflowDefinitionBuilder AddDescription(string description)
     {
@@ -39,10 +40,15 @@ public class WorkflowDefinitionBuilder : IWorkflowDefinitionBuilder
         return this;
     }
 
+    public IWorkflowDefinitionBuilder AddId(Guid id)
+    {
+        _workflowId = id;
+        return this;
+    }
+
     public WorkflowDefinition Build()
     {
-        Guid guid = new();
-        _workflowDefinition.Id = guid;
+        _workflowDefinition.Id = _workflowId ?? Guid.NewGuid();
         return _workflowDefinition;
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the use of `new Guid()` with `Guid.NewGuid()` to generate proper non-empty GUIDs for workflow definitions.
- Allow callers to provide a deterministic ID when constructing a definition (useful for tests or fixtures).

### Description
- Added a nullable field `private Guid? _workflowId` to `WorkflowDefinitionBuilder` and an `AddId(Guid id)` method to the builder and interface `IWorkflowDefinitionBuilder`.
- Updated `Build()` to set `Id` to `_workflowId ?? Guid.NewGuid()` so a provided ID is used when present, otherwise a new GUID is generated.
- Changes applied in `src/GvatarWorkflow/Entities/WorkflowDefinition.cs` and `src/GvatarWorkflow/Entities/Interfaces/IWorkflowDefinitionBuilder.cs`.

### Testing
- No automated tests were run for this change.
- No test failures reported (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e0a58b6a08332b01281e22e72dd87)