### PR TITLE
Persist workflow instance after status changes, waits, and steps

### DIFF
--- a/src/GvatarWorkflow/Services/WorkflowExecutor.cs
+++ b/src/GvatarWorkflow/Services/WorkflowExecutor.cs
@@ -12,8 +12,9 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
 
     public async Task ExecuteWorkflowInstance(Guid workflowInstanceId)
     {
-    WorkflowInstance currentWorkflowInstance = await _persistenceProvider.GetWorkflowInstanceById(workflowInstanceId);
+        WorkflowInstance currentWorkflowInstance = await _persistenceProvider.GetWorkflowInstanceById(workflowInstanceId);
         currentWorkflowInstance.Status = "In Progress";
+        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
 
         while (currentWorkflowInstance.NextPendingStepNames.Count > 0)
         {
@@ -27,6 +28,7 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
                 {
                     currentWorkflowInstance.TaskCompletionSource = new TaskCompletionSource<bool>();
                     currentWorkflowInstance.EventTriggerName = step.WaitFor?.Item1;
+                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
                     await currentWorkflowInstance.TaskCompletionSource.Task; // Waits for this task to complete before continuing
                     step.WaitFor?.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
                 }
@@ -41,10 +43,13 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
                     currentWorkflowInstance.NextPendingStepNames.AddRange(step.ChildrenSteps);
                     currentWorkflowInstance.NextPendingStepNames = currentWorkflowInstance.NextPendingStepNames.Distinct().ToList();
                 }
+
+                await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
             }
         }
 
         currentWorkflowInstance.Status = "Completed";
+        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
     }
 
     public Task ContinueWorkflowInstance(WorkflowInstance workflowInstance, string eventTriggerName)


### PR DESCRIPTION
### Motivation
- Ensure workflow state is durably stored after status transitions, before pausing on `WaitFor`, and after each step to avoid lost progress.
- Capture the `EventTriggerName` and `TaskCompletionSource` state before awaiting so paused workflows can be resumed reliably.
- Reduce the risk of orphaned or inconsistent `WorkflowInstance` objects during long-running or externally-triggered waits.

### Description
- Call `_persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance)` after setting status to `In Progress` in `ExecuteWorkflowInstance`.
- Persist the workflow instance after assigning `EventTriggerName` and `TaskCompletionSource`, i.e. before awaiting a `WaitFor`.
- Persist after completing each step and again after marking the workflow `Completed` in `src/GvatarWorkflow/Services/WorkflowExecutor.cs`.
- All changes are contained within the `ExecuteWorkflowInstance` method to ensure state is saved at each transition.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e0930766c8332ac9e967d1fb2e651)