### PR TITLE
Move EF Core support into optional project and improve persistence/dispatching

### DIFF
--- a/gvatar-workflow.sln
+++ b/gvatar-workflow.sln
@@ -18,6 +18,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample2", "src\Sample2\Sample2.csproj", "{C511858D-8AF5-4168-97FF-627E5A6EACD2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GvatarWorkflow.EfCore", "src\GvatarWorkflow.EfCore\GvatarWorkflow.EfCore.csproj", "{60A856CE-263D-427A-AE46-9E7E07EA8DC3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GvatarWorkflow.Tests", "test\GvatarWorkflow.Tests\GvatarWorkflow.Tests.csproj", "{0F5DCF80-FF5F-4AFF-B7C8-4BACE7690AF0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +40,14 @@ Global
 		{C511858D-8AF5-4168-97FF-627E5A6EACD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C511858D-8AF5-4168-97FF-627E5A6EACD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C511858D-8AF5-4168-97FF-627E5A6EACD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F5DCF80-FF5F-4AFF-B7C8-4BACE7690AF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F5DCF80-FF5F-4AFF-B7C8-4BACE7690AF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F5DCF80-FF5F-4AFF-B7C8-4BACE7690AF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F5DCF80-FF5F-4AFF-B7C8-4BACE7690AF0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60A856CE-263D-427A-AE46-9E7E07EA8DC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60A856CE-263D-427A-AE46-9E7E07EA8DC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60A856CE-263D-427A-AE46-9E7E07EA8DC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60A856CE-263D-427A-AE46-9E7E07EA8DC3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -44,6 +56,8 @@ Global
 		{F1A8B459-BBB8-4577-8104-6593A81E2041} = {6C79000A-6598-4811-9179-63B7ABF24A77}
 		{86C23E22-8DE6-4222-9287-B56611052383} = {6C79000A-6598-4811-9179-63B7ABF24A77}
 		{C511858D-8AF5-4168-97FF-627E5A6EACD2} = {6C79000A-6598-4811-9179-63B7ABF24A77}
+		{60A856CE-263D-427A-AE46-9E7E07EA8DC3} = {6C79000A-6598-4811-9179-63B7ABF24A77}
+		{0F5DCF80-FF5F-4AFF-B7C8-4BACE7690AF0} = {C7A63CB7-451B-4069-9C5C-168C3BBA11C0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {639A9BEE-25CB-4EE4-8027-69AB7E1DBD9F}

--- a/src/GvatarWorkflow.EfCore/EntityFrameworkPersistenceProvider.cs
+++ b/src/GvatarWorkflow.EfCore/EntityFrameworkPersistenceProvider.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using GvatarWorkflow.Entities;
+using GvatarWorkflow.Providers.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace GvatarWorkflow.Providers;
+
+public sealed class EntityFrameworkPersistenceProvider(WorkflowDbContext dbContext) : IPersistenceProvider
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly WorkflowDbContext _dbContext = dbContext;
+
+    public Task<Guid> CreateNewWorkflowInstance(WorkflowDefinition workflowDefinition)
+    {
+        return CreateNewWorkflowInstance(workflowDefinition, null);
+    }
+
+    public async Task<Guid> CreateNewWorkflowInstance(WorkflowDefinition workflowDefinition, object? input)
+    {
+        Guid newGuid = Guid.NewGuid();
+        WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Name], input, workflowDefinition)
+        {
+            Id = newGuid
+        };
+
+        _dbContext.WorkflowInstances.Add(ToRecord(newWorkflowInstance));
+        await _dbContext.SaveChangesAsync();
+
+        return newGuid;
+    }
+
+    public async Task<IEnumerable<WorkflowInstance>> GetAllWorkflowInstancesByIds(IEnumerable<Guid> ids)
+    {
+        List<WorkflowInstanceRecord> records = await _dbContext.WorkflowInstances
+            .Where(record => ids.Contains(record.Id))
+            .ToListAsync();
+
+        return records.Select(ToWorkflowInstance).ToList();
+    }
+
+    public async Task<WorkflowInstance> GetWorkflowInstanceById(Guid workflowInstanceId)
+    {
+        WorkflowInstanceRecord? record = await _dbContext.WorkflowInstances
+            .FirstOrDefaultAsync(instance => instance.Id == workflowInstanceId);
+
+        if (record is null)
+        {
+            throw new KeyNotFoundException($"No workflow instance found for id {workflowInstanceId}.");
+        }
+
+        return ToWorkflowInstance(record);
+    }
+
+    public async Task PersistWorkflowInstance(WorkflowInstance workflowInstance)
+    {
+        WorkflowInstanceRecord? record = await _dbContext.WorkflowInstances
+            .FirstOrDefaultAsync(instance => instance.Id == workflowInstance.Id);
+
+        if (record is null)
+        {
+            throw new KeyNotFoundException($"No workflow instance found for id {workflowInstance.Id}.");
+        }
+
+        UpdateRecord(record, workflowInstance);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private static WorkflowInstanceRecord ToRecord(WorkflowInstance workflowInstance)
+    {
+        string definitionJson = JsonSerializer.Serialize(WorkflowDefinitionRecord.FromDefinition(workflowInstance.WorkflowDefinition), JsonOptions);
+        return new WorkflowInstanceRecord
+        {
+            Id = workflowInstance.Id,
+            Status = workflowInstance.Status,
+            CurrentStepObjectContextJson = SerializeOptional(workflowInstance.CurrentStepObjectContext),
+            CurrentStepObjectContextType = workflowInstance.CurrentStepObjectContext?.GetType().AssemblyQualifiedName,
+            PreviousCompletedStepNamesJson = JsonSerializer.Serialize(workflowInstance.PreviousCompletedStepNames, JsonOptions),
+            NextPendingStepNamesJson = JsonSerializer.Serialize(workflowInstance.NextPendingStepNames, JsonOptions),
+            WorkflowDefinitionJson = definitionJson
+        };
+    }
+
+    private static void UpdateRecord(WorkflowInstanceRecord record, WorkflowInstance workflowInstance)
+    {
+        record.Status = workflowInstance.Status;
+        record.CurrentStepObjectContextJson = SerializeOptional(workflowInstance.CurrentStepObjectContext);
+        record.CurrentStepObjectContextType = workflowInstance.CurrentStepObjectContext?.GetType().AssemblyQualifiedName;
+        record.PreviousCompletedStepNamesJson = JsonSerializer.Serialize(workflowInstance.PreviousCompletedStepNames, JsonOptions);
+        record.NextPendingStepNamesJson = JsonSerializer.Serialize(workflowInstance.NextPendingStepNames, JsonOptions);
+        record.WorkflowDefinitionJson = JsonSerializer.Serialize(WorkflowDefinitionRecord.FromDefinition(workflowInstance.WorkflowDefinition), JsonOptions);
+    }
+
+    private static WorkflowInstance ToWorkflowInstance(WorkflowInstanceRecord record)
+    {
+        WorkflowDefinitionRecord definitionRecord = JsonSerializer.Deserialize<WorkflowDefinitionRecord>(record.WorkflowDefinitionJson, JsonOptions)
+            ?? throw new InvalidOperationException("Workflow definition data is missing.");
+
+        WorkflowDefinition workflowDefinition = definitionRecord.ToDefinition();
+        object? context = DeserializeOptional(record.CurrentStepObjectContextJson, record.CurrentStepObjectContextType);
+        List<string> previous = JsonSerializer.Deserialize<List<string>>(record.PreviousCompletedStepNamesJson, JsonOptions) ?? [];
+        List<string> next = JsonSerializer.Deserialize<List<string>>(record.NextPendingStepNamesJson, JsonOptions) ?? [];
+
+        return new WorkflowInstance(record.Status, previous, next, context, workflowDefinition)
+        {
+            Id = record.Id
+        };
+    }
+
+    private static string? SerializeOptional(object? value)
+    {
+        return value is null ? null : JsonSerializer.Serialize(value, JsonOptions);
+    }
+
+    private static object? DeserializeOptional(string? json, string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        Type? type = string.IsNullOrWhiteSpace(typeName) ? null : Type.GetType(typeName);
+        return type is null ? JsonSerializer.Deserialize<object>(json, JsonOptions) : JsonSerializer.Deserialize(json, type, JsonOptions);
+    }
+}

--- a/src/GvatarWorkflow.EfCore/GvatarWorkflow.EfCore.csproj
+++ b/src/GvatarWorkflow.EfCore/GvatarWorkflow.EfCore.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GvatarWorkflow\GvatarWorkflow.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/GvatarWorkflow.EfCore/WorkflowDbContext.cs
+++ b/src/GvatarWorkflow.EfCore/WorkflowDbContext.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace GvatarWorkflow.Providers;
+
+public sealed class WorkflowDbContext(DbContextOptions<WorkflowDbContext> options) : DbContext(options)
+{
+    public DbSet<WorkflowInstanceRecord> WorkflowInstances => Set<WorkflowInstanceRecord>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<WorkflowInstanceRecord>()
+            .HasKey(instance => instance.Id);
+    }
+}
+
+public sealed class WorkflowInstanceRecord
+{
+    public Guid Id { get; set; }
+    public string Status { get; set; } = "";
+    public string? CurrentStepObjectContextJson { get; set; }
+    public string? CurrentStepObjectContextType { get; set; }
+    public string PreviousCompletedStepNamesJson { get; set; } = "[]";
+    public string NextPendingStepNamesJson { get; set; } = "[]";
+    public string WorkflowDefinitionJson { get; set; } = "";
+}

--- a/src/GvatarWorkflow.EfCore/WorkflowDefinitionRecord.cs
+++ b/src/GvatarWorkflow.EfCore/WorkflowDefinitionRecord.cs
@@ -1,0 +1,63 @@
+using GvatarWorkflow.Entities;
+
+namespace GvatarWorkflow.Providers;
+
+public sealed class WorkflowDefinitionRecord
+{
+    public Guid Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public int Version { get; set; }
+    public List<StepRecord> Steps { get; set; } = [];
+
+    public static WorkflowDefinitionRecord FromDefinition(WorkflowDefinition workflowDefinition)
+    {
+        return new WorkflowDefinitionRecord
+        {
+            Id = workflowDefinition.Id,
+            Name = workflowDefinition.Name,
+            Description = workflowDefinition.Description,
+            Version = workflowDefinition.Version,
+            Steps = workflowDefinition.Steps.Select(StepRecord.FromStep).ToList()
+        };
+    }
+
+    public WorkflowDefinition ToDefinition()
+    {
+        return new WorkflowDefinition
+        {
+            Id = Id,
+            Name = Name,
+            Description = Description,
+            Version = Version,
+            Steps = Steps.Select(stepRecord => stepRecord.ToStep()).ToList()
+        };
+    }
+}
+
+public sealed class StepRecord
+{
+    public string Name { get; set; } = "";
+    public string FunctionDelegateName { get; set; } = "";
+    public List<string>? ChildrenSteps { get; set; }
+
+    public static StepRecord FromStep(Step step)
+    {
+        return new StepRecord
+        {
+            Name = step.Name,
+            FunctionDelegateName = step.FunctionDelegateName,
+            ChildrenSteps = step.ChildrenSteps?.ToList()
+        };
+    }
+
+    public Step ToStep()
+    {
+        return new Step
+        {
+            Name = Name,
+            FunctionDelegateName = FunctionDelegateName,
+            ChildrenSteps = ChildrenSteps
+        };
+    }
+}

--- a/src/GvatarWorkflow/Context/DelegateContext.cs
+++ b/src/GvatarWorkflow/Context/DelegateContext.cs
@@ -1,5 +1,7 @@
 ﻿using GvatarWorkflow.Entities.Interfaces;
 using System.Reflection;
+using System;
+using System.Linq;
 
 namespace GvatarWorkflow.Context;
 
@@ -9,9 +11,9 @@ public class DelegateContext
 
     public void InitialPopulationOfAssemblyTypes()
     {
-        Assembly? currentAssembly = Assembly.GetEntryAssembly();
-        _types = currentAssembly?.GetTypes()
-                                .Where(type => typeof(IDelegate).IsAssignableFrom(type) && type.IsClass);
+        _types = AppDomain.CurrentDomain.GetAssemblies()
+            .SelectMany(GetLoadableTypes)
+            .Where(type => typeof(IDelegate).IsAssignableFrom(type) && type is { IsClass: true, IsAbstract: false });
     }
 
     public object? InvokeDelegate(string delegateName)
@@ -36,5 +38,17 @@ public class DelegateContext
         }
 
         return input;
+    }
+
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(type => type is not null)!;
+        }
     }
 }

--- a/src/GvatarWorkflow/Providers/EntityFrameworkPersistenceProvider.cs
+++ b/src/GvatarWorkflow/Providers/EntityFrameworkPersistenceProvider.cs
@@ -1,5 +1,0 @@
-﻿namespace GvatarWorkflow.Providers;
-
-public class EntityFrameworkPersistenceProvider
-{
-}

--- a/src/GvatarWorkflow/Providers/SingletonInMemoryPersistenceProvider.cs
+++ b/src/GvatarWorkflow/Providers/SingletonInMemoryPersistenceProvider.cs
@@ -12,19 +12,16 @@ public class SingletonInMemoryPersistenceProvider : IPersistenceProvider
     }
     public Task<Guid> CreateNewWorkflowInstance(WorkflowDefinition workflowDefinition, object? input)
     {
-        lock(_instances)
+        lock (_instances)
         {
-            return Task.Run(() =>
+            Guid newGuid = Guid.NewGuid();
+            WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Name], null, workflowDefinition)
             {
-                Guid newGuid = Guid.NewGuid();
-                WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Name], null, workflowDefinition)
-                {
-                    Id = newGuid,
-                    CurrentStepObjectContext = input
-                };
-                _instances.Add(newWorkflowInstance);
-                return newGuid;
-            });
+                Id = newGuid,
+                CurrentStepObjectContext = input
+            };
+            _instances.Add(newWorkflowInstance);
+            return Task.FromResult(newGuid);
         }
     }
 
@@ -32,10 +29,7 @@ public class SingletonInMemoryPersistenceProvider : IPersistenceProvider
     {
         lock (_instances)
         {
-            return Task.Run(() =>
-            {
-                return _instances.Where(instance => ids.Contains(instance.Id));
-            });
+            return Task.FromResult<IEnumerable<WorkflowInstance>>(_instances.Where(instance => ids.Contains(instance.Id)).ToList());
         }
     }
 
@@ -43,10 +37,13 @@ public class SingletonInMemoryPersistenceProvider : IPersistenceProvider
     {
         lock (_instances) 
         {
-            return Task.Run(() =>
+            WorkflowInstance? instance = _instances.FirstOrDefault(item => item.Id == workflowInstanceId);
+            if (instance is null)
             {
-                return _instances.Where(instance => instance.Id == workflowInstanceId).First();
-            });
+                throw new KeyNotFoundException($"No workflow instance found for id {workflowInstanceId}.");
+            }
+
+            return Task.FromResult(instance);
         }
     }
 
@@ -54,12 +51,15 @@ public class SingletonInMemoryPersistenceProvider : IPersistenceProvider
     {
         lock(_instances)
         {
-            return Task.Run(() =>
+            var existing = _instances.FirstOrDefault(instance => instance.Id == workflowInstance.Id);
+            if (existing is null)
             {
-                var existing = _instances.First(instance => instance.Id == workflowInstance.Id);
-                _instances.Remove(existing);
-                _instances.Add(workflowInstance);
-            });
+                throw new KeyNotFoundException($"No workflow instance found for id {workflowInstance.Id}.");
+            }
+
+            _instances.Remove(existing);
+            _instances.Add(workflowInstance);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/GvatarWorkflow/Services/WorkflowExecutor.cs
+++ b/src/GvatarWorkflow/Services/WorkflowExecutor.cs
@@ -26,11 +26,14 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
             {
                 if (step.WaitFor is not null)
                 {
+                    currentWorkflowInstance.Status = "Waiting";
                     currentWorkflowInstance.TaskCompletionSource = new TaskCompletionSource<bool>();
                     currentWorkflowInstance.EventTriggerName = step.WaitFor?.Item1;
                     await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
                     await currentWorkflowInstance.TaskCompletionSource.Task; // Waits for this task to complete before continuing
                     step.WaitFor?.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
+                    currentWorkflowInstance.Status = "In Progress";
+                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
                 }
 
                 var output = _delegateContext.InvokeDelegate(step.FunctionDelegateName, currentWorkflowInstance.CurrentStepObjectContext, step.Condition);

--- a/test/GvatarWorkflow.Tests/GvatarWorkflow.Tests.csproj
+++ b/test/GvatarWorkflow.Tests/GvatarWorkflow.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\GvatarWorkflow\GvatarWorkflow.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/GvatarWorkflow.Tests/PersistenceTests.cs
+++ b/test/GvatarWorkflow.Tests/PersistenceTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GvatarWorkflow.Context;
+using GvatarWorkflow.Entities;
+using GvatarWorkflow.Entities.Interfaces;
+using GvatarWorkflow.Providers.Interfaces;
+using GvatarWorkflow.Services;
+using Xunit;
+
+namespace GvatarWorkflow.Tests;
+
+public class PersistenceTests
+{
+    [Fact]
+    public async Task ExecuteWorkflowInstance_PersistsUpdates()
+    {
+        DelegateContext delegateContext = new();
+        delegateContext.InitialPopulationOfAssemblyTypes();
+
+        TrackingPersistenceProvider persistenceProvider = new();
+        WorkflowExecutor executor = new(persistenceProvider, delegateContext);
+
+        WorkflowDefinition workflowDefinition = new()
+        {
+            Name = "Test",
+            Description = "Test",
+            Version = 1,
+            Steps =
+            [
+                new Step
+                {
+                    Name = "Step1",
+                    FunctionDelegateName = nameof(EchoDelegate),
+                    ChildrenSteps = null,
+                    Condition = _ => true
+                }
+            ]
+        };
+
+        Guid workflowInstanceId = await persistenceProvider.CreateNewWorkflowInstance(workflowDefinition, 5);
+
+        await executor.ExecuteWorkflowInstance(workflowInstanceId);
+
+        WorkflowInstance instance = await persistenceProvider.GetWorkflowInstanceById(workflowInstanceId);
+
+        Assert.Equal("Completed", instance.Status);
+        Assert.Contains("Step1", instance.PreviousCompletedStepNames);
+        Assert.True(persistenceProvider.PersistCount >= 2, "Expected workflow updates to be persisted more than once.");
+    }
+
+    private sealed class TrackingPersistenceProvider : IPersistenceProvider
+    {
+        private readonly Dictionary<Guid, WorkflowInstance> _instances = new();
+
+        public int PersistCount { get; private set; }
+
+        public Task<Guid> CreateNewWorkflowInstance(WorkflowDefinition workflowDefinition)
+        {
+            return CreateNewWorkflowInstance(workflowDefinition, null);
+        }
+
+        public Task<Guid> CreateNewWorkflowInstance(WorkflowDefinition workflowDefinition, object? input)
+        {
+            Guid newGuid = Guid.NewGuid();
+            WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Name], input, workflowDefinition)
+            {
+                Id = newGuid
+            };
+            _instances[newGuid] = newWorkflowInstance;
+            return Task.FromResult(newGuid);
+        }
+
+        public Task<IEnumerable<WorkflowInstance>> GetAllWorkflowInstancesByIds(IEnumerable<Guid> ids)
+        {
+            return Task.FromResult<IEnumerable<WorkflowInstance>>(_instances.Values.Where(instance => ids.Contains(instance.Id)).ToList());
+        }
+
+        public Task<WorkflowInstance> GetWorkflowInstanceById(Guid workflowInstanceId)
+        {
+            return Task.FromResult(_instances[workflowInstanceId]);
+        }
+
+        public Task PersistWorkflowInstance(WorkflowInstance workflowInstance)
+        {
+            PersistCount += 1;
+            _instances[workflowInstance.Id] = workflowInstance;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class EchoDelegate : IDelegate
+    {
+        public object? Execute(object input)
+        {
+            return input;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Avoid forcing an EF Core dependency on the core library so consumers can opt-in to the EF persistence provider by referencing a separate package.  
- Keep the core package lightweight while still providing a ready-to-use EF Core persistence implementation for consumers who need it.  
- Improve runtime robustness by hardening delegate discovery across assemblies and handling partial type-load scenarios.  
- Make persistence semantics clearer and simpler by surfacing missing-instance errors and removing unnecessary background task usage in the in-memory provider.

### Description

- Added a new optional project `src/GvatarWorkflow.EfCore` containing `EntityFrameworkPersistenceProvider`, `WorkflowDbContext`, and `WorkflowDefinitionRecord`/`StepRecord`, and added `Microsoft.EntityFrameworkCore` to that project only.  
- Removed the `Microsoft.EntityFrameworkCore` package from the core `src/GvatarWorkflow/GvatarWorkflow.csproj` and removed the placeholder EF file from the core so EF is no longer a transitive requirement.  
- Updated the solution file to include the new `GvatarWorkflow.EfCore` project and relocated the EF implementation files into that project.  
- Refactored core behavior: `DelegateContext.InitialPopulationOfAssemblyTypes` now scans `AppDomain.CurrentDomain.GetAssemblies()` and handles `ReflectionTypeLoadException`, `SingletonInMemoryPersistenceProvider` now uses `Task.FromResult`/`Task.CompletedTask` and throws `KeyNotFoundException` for missing instances, and `WorkflowExecutor` persists `Status` updates around waits (`Waiting` / `In Progress`).

### Testing

- Added a test project `test/GvatarWorkflow.Tests` and a unit `PersistenceTests` that validates persistence calls and execution state transitions.  
- No automated tests were executed in this environment because the .NET SDK / `dotnet` command was not available, so there are no test run results to report.  
- The new tests are intended to be run with `dotnet test` in CI or on a developer machine.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e07749ebc8332985a147b168f7bcf)