### PR TITLE
Persist step IDs instead of names and fix in-memory provider creation

### DIFF
--- a/src/GvatarWorkflow.EfCore/EntityFrameworkPersistenceProvider.cs
+++ b/src/GvatarWorkflow.EfCore/EntityFrameworkPersistenceProvider.cs
@@ -18,7 +18,7 @@ public sealed class EntityFrameworkPersistenceProvider(WorkflowDbContext dbConte
     public async Task<Guid> CreateNewWorkflowInstance(WorkflowDefinition workflowDefinition, object? input)
     {
         Guid newGuid = Guid.NewGuid();
-        WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Name], input, workflowDefinition)
+        WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Id], input, workflowDefinition)
         {
             Id = newGuid
         };
@@ -74,8 +74,8 @@ public sealed class EntityFrameworkPersistenceProvider(WorkflowDbContext dbConte
             Status = workflowInstance.Status,
             CurrentStepObjectContextJson = SerializeOptional(workflowInstance.CurrentStepObjectContext),
             CurrentStepObjectContextType = workflowInstance.CurrentStepObjectContext?.GetType().AssemblyQualifiedName,
-            PreviousCompletedStepNamesJson = JsonSerializer.Serialize(workflowInstance.PreviousCompletedStepNames, JsonOptions),
-            NextPendingStepNamesJson = JsonSerializer.Serialize(workflowInstance.NextPendingStepNames, JsonOptions),
+            PreviousCompletedStepIdsJson = JsonSerializer.Serialize(workflowInstance.PreviousCompletedStepIds, JsonOptions),
+            NextPendingStepIdsJson = JsonSerializer.Serialize(workflowInstance.NextPendingStepIds, JsonOptions),
             WorkflowDefinitionJson = definitionJson
         };
     }
@@ -85,8 +85,8 @@ public sealed class EntityFrameworkPersistenceProvider(WorkflowDbContext dbConte
         record.Status = workflowInstance.Status;
         record.CurrentStepObjectContextJson = SerializeOptional(workflowInstance.CurrentStepObjectContext);
         record.CurrentStepObjectContextType = workflowInstance.CurrentStepObjectContext?.GetType().AssemblyQualifiedName;
-        record.PreviousCompletedStepNamesJson = JsonSerializer.Serialize(workflowInstance.PreviousCompletedStepNames, JsonOptions);
-        record.NextPendingStepNamesJson = JsonSerializer.Serialize(workflowInstance.NextPendingStepNames, JsonOptions);
+        record.PreviousCompletedStepIdsJson = JsonSerializer.Serialize(workflowInstance.PreviousCompletedStepIds, JsonOptions);
+        record.NextPendingStepIdsJson = JsonSerializer.Serialize(workflowInstance.NextPendingStepIds, JsonOptions);
         record.WorkflowDefinitionJson = JsonSerializer.Serialize(WorkflowDefinitionRecord.FromDefinition(workflowInstance.WorkflowDefinition), JsonOptions);
     }
 
@@ -97,8 +97,8 @@ public sealed class EntityFrameworkPersistenceProvider(WorkflowDbContext dbConte
 
         WorkflowDefinition workflowDefinition = definitionRecord.ToDefinition();
         object? context = DeserializeOptional(record.CurrentStepObjectContextJson, record.CurrentStepObjectContextType);
-        List<string> previous = JsonSerializer.Deserialize<List<string>>(record.PreviousCompletedStepNamesJson, JsonOptions) ?? [];
-        List<string> next = JsonSerializer.Deserialize<List<string>>(record.NextPendingStepNamesJson, JsonOptions) ?? [];
+        List<Guid> previous = JsonSerializer.Deserialize<List<Guid>>(record.PreviousCompletedStepIdsJson, JsonOptions) ?? [];
+        List<Guid> next = JsonSerializer.Deserialize<List<Guid>>(record.NextPendingStepIdsJson, JsonOptions) ?? [];
 
         return new WorkflowInstance(record.Status, previous, next, context, workflowDefinition)
         {

--- a/src/GvatarWorkflow.EfCore/WorkflowDbContext.cs
+++ b/src/GvatarWorkflow.EfCore/WorkflowDbContext.cs
@@ -19,7 +19,7 @@ public sealed class WorkflowInstanceRecord
     public string Status { get; set; } = "";
     public string? CurrentStepObjectContextJson { get; set; }
     public string? CurrentStepObjectContextType { get; set; }
-    public string PreviousCompletedStepNamesJson { get; set; } = "[]";
-    public string NextPendingStepNamesJson { get; set; } = "[]";
+    public string PreviousCompletedStepIdsJson { get; set; } = "[]";
+    public string NextPendingStepIdsJson { get; set; } = "[]";
     public string WorkflowDefinitionJson { get; set; } = "";
 }

--- a/src/GvatarWorkflow/Providers/SingletonInMemoryPersistenceProvider.cs
+++ b/src/GvatarWorkflow/Providers/SingletonInMemoryPersistenceProvider.cs
@@ -15,17 +15,13 @@ public class SingletonInMemoryPersistenceProvider : IPersistenceProvider
         lock (_instances)
         {
             Guid newGuid = Guid.NewGuid();
-            WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Name], null, workflowDefinition)
+            WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Id], null, workflowDefinition)
             {
-                Guid newGuid = Guid.NewGuid();
-                WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Id], null, workflowDefinition)
-                {
-                    Id = newGuid,
-                    CurrentStepObjectContext = input
-                };
-                _instances.Add(newWorkflowInstance);
-                return newGuid;
-            });
+                Id = newGuid,
+                CurrentStepObjectContext = input
+            };
+            _instances.Add(newWorkflowInstance);
+            return newGuid;
         }
     }
 

--- a/test/GvatarWorkflow.Tests/PersistenceTests.cs
+++ b/test/GvatarWorkflow.Tests/PersistenceTests.cs
@@ -46,7 +46,7 @@ public class PersistenceTests
         WorkflowInstance instance = await persistenceProvider.GetWorkflowInstanceById(workflowInstanceId);
 
         Assert.Equal("Completed", instance.Status);
-        Assert.Contains("Step1", instance.PreviousCompletedStepNames);
+        Assert.Contains(workflowDefinition.Steps[0].Id, instance.PreviousCompletedStepIds);
         Assert.True(persistenceProvider.PersistCount >= 2, "Expected workflow updates to be persisted more than once.");
     }
 
@@ -64,7 +64,7 @@ public class PersistenceTests
         public Task<Guid> CreateNewWorkflowInstance(WorkflowDefinition workflowDefinition, object? input)
         {
             Guid newGuid = Guid.NewGuid();
-            WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Name], input, workflowDefinition)
+            WorkflowInstance newWorkflowInstance = new("New", [], [workflowDefinition.Steps[0].Id], input, workflowDefinition)
             {
                 Id = newGuid
             };


### PR DESCRIPTION
### Motivation
- Fix a bug in the in-memory persistence provider where instance construction contained duplicated/incorrect syntax and did not set the instance properly.  
- Ensure workflow persistence references step identifiers consistently by storing step `Id` values instead of step `Name` values.  
- Update the EF Core persistence schema to reflect that completed/pending steps are stored as IDs.  
- Align unit tests to the updated persistence semantics so they assert on step IDs.

### Description
- Corrected `SingletonInMemoryPersistenceProvider.CreateNewWorkflowInstance` to properly construct the `WorkflowInstance`, set `Id` and `CurrentStepObjectContext`, and add it to the `_instances` list.  
- Renamed EF Core record fields in `WorkflowDbContext.cs` from `PreviousCompletedStepNamesJson` / `NextPendingStepNamesJson` to `PreviousCompletedStepIdsJson` / `NextPendingStepIdsJson`.  
- Updated `EntityFrameworkPersistenceProvider` to create instances using `workflowDefinition.Steps[0].Id`, to serialize/deserialize `PreviousCompletedStepIds` and `NextPendingStepIds` as `List<Guid>`, and to map the new record field names.  
- Updated tests in `PersistenceTests.cs` (and the `TrackingPersistenceProvider` test helper) to create and assert workflow instances using step `Id` values instead of names.

### Testing
- No automated tests were executed because the `dotnet` CLI was unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f15f11c488332b5482c8368d4383b)