### PR TITLE
Add durable workflow event waits and event store (in-memory + EF Core)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Step step2b = new()
 
 When defining a step we can specify a tuple with the first input being the name of the continue workflow event trigger and the second
 input being a Function delegate will be ran before the continuation of the workflow on the continue workflow event trigger.
+The wait state is persisted, so the workflow can be resumed after a process restart or by a worker running on another node. Correlation
+keys are stored alongside the wait state to ensure the correct workflow instance resumes.
 
 ```csharp
 Step step2a = new()
@@ -168,11 +170,17 @@ Step step2a = new()
 };
 ```
 
-The workflow can be continued by calling the ContinueWorkflowInstance method on the workflow executor with the Workflow Instance and name
-of the continue workflow event trigger passed to it.
+The workflow can be continued by calling the ContinueWorkflowInstance method on the workflow executor with the event name and the
+correlation keys. Because waits/events are durable, the event can be posted from another process or node. By default, the executor
+correlates waits using the workflow instance id.
 
 ```csharp
-await _workflowExecutor.ContinueWorkflowInstance(workflowInstance, eventTriggerName);
+WorkflowEventKey[] correlationKeys =
+[
+    new WorkflowEventKey("workflowInstanceId", workflowInstanceId.ToString())
+];
+
+await _workflowExecutor.ContinueWorkflowInstance(eventTriggerName, correlationKeys);
 ```
 
 ## License

--- a/src/GvatarWorkflow.EfCore/EntityFrameworkWorkflowEventStore.cs
+++ b/src/GvatarWorkflow.EfCore/EntityFrameworkWorkflowEventStore.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using GvatarWorkflow.Entities;
+using GvatarWorkflow.Providers.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace GvatarWorkflow.Providers;
+
+public sealed class EntityFrameworkWorkflowEventStore(WorkflowDbContext dbContext) : IWorkflowEventStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly WorkflowDbContext _dbContext = dbContext;
+
+    public async Task<WorkflowEventWait?> GetWaitForStep(Guid workflowInstanceId, Guid stepId)
+    {
+        WorkflowEventWaitRecord? record = await _dbContext.WorkflowEventWaits
+            .FirstOrDefaultAsync(wait => wait.WorkflowInstanceId == workflowInstanceId && wait.StepId == stepId);
+
+        return record is null ? null : ToWait(record);
+    }
+
+    public async Task<WorkflowEventWait> CreateWait(WorkflowEventWait wait)
+    {
+        WorkflowEventWaitRecord record = ToRecord(wait);
+        _dbContext.WorkflowEventWaits.Add(record);
+        await _dbContext.SaveChangesAsync();
+        return wait;
+    }
+
+    public async Task<IReadOnlyList<WorkflowEventWait>> GetWaitsByEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys)
+    {
+        List<WorkflowEventWaitRecord> records = await _dbContext.WorkflowEventWaits
+            .Where(wait => wait.EventName == eventName)
+            .ToListAsync();
+
+        return records
+            .Select(ToWait)
+            .Where(wait => CorrelationKeysMatch(wait.CorrelationKeys, correlationKeys))
+            .ToList();
+    }
+
+    public async Task RemoveWait(Guid waitId)
+    {
+        WorkflowEventWaitRecord? existing = await _dbContext.WorkflowEventWaits
+            .FirstOrDefaultAsync(wait => wait.Id == waitId);
+
+        if (existing is not null)
+        {
+            _dbContext.WorkflowEventWaits.Remove(existing);
+            await _dbContext.SaveChangesAsync();
+        }
+    }
+
+    public async Task<WorkflowEventRecord> RecordEvent(WorkflowEventRecord workflowEvent)
+    {
+        WorkflowEventRecordEntry record = ToRecord(workflowEvent);
+        _dbContext.WorkflowEvents.Add(record);
+        await _dbContext.SaveChangesAsync();
+        return workflowEvent;
+    }
+
+    public async Task<WorkflowEventRecord?> FindMatchingEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys)
+    {
+        List<WorkflowEventRecordEntry> records = await _dbContext.WorkflowEvents
+            .Where(evt => evt.EventName == eventName)
+            .ToListAsync();
+
+        return records
+            .Select(ToEvent)
+            .FirstOrDefault(evt => CorrelationKeysMatch(evt.CorrelationKeys, correlationKeys));
+    }
+
+    public async Task RemoveEvent(Guid eventId)
+    {
+        WorkflowEventRecordEntry? existing = await _dbContext.WorkflowEvents
+            .FirstOrDefaultAsync(evt => evt.Id == eventId);
+
+        if (existing is not null)
+        {
+            _dbContext.WorkflowEvents.Remove(existing);
+            await _dbContext.SaveChangesAsync();
+        }
+    }
+
+    private static WorkflowEventWaitRecord ToRecord(WorkflowEventWait wait)
+    {
+        return new WorkflowEventWaitRecord
+        {
+            Id = wait.Id,
+            WorkflowInstanceId = wait.WorkflowInstanceId,
+            StepId = wait.StepId,
+            StepName = wait.StepName,
+            EventName = wait.EventName,
+            CorrelationKeysJson = JsonSerializer.Serialize(wait.CorrelationKeys, JsonOptions),
+            CreatedAtUtc = wait.CreatedAtUtc
+        };
+    }
+
+    private static WorkflowEventWait ToWait(WorkflowEventWaitRecord record)
+    {
+        List<WorkflowEventKey> keys = JsonSerializer.Deserialize<List<WorkflowEventKey>>(record.CorrelationKeysJson, JsonOptions) ?? [];
+        return new WorkflowEventWait
+        {
+            Id = record.Id,
+            WorkflowInstanceId = record.WorkflowInstanceId,
+            StepId = record.StepId,
+            StepName = record.StepName,
+            EventName = record.EventName,
+            CorrelationKeys = keys,
+            CreatedAtUtc = record.CreatedAtUtc
+        };
+    }
+
+    private static WorkflowEventRecordEntry ToRecord(WorkflowEventRecord workflowEvent)
+    {
+        return new WorkflowEventRecordEntry
+        {
+            Id = workflowEvent.Id,
+            EventName = workflowEvent.EventName,
+            CorrelationKeysJson = JsonSerializer.Serialize(workflowEvent.CorrelationKeys, JsonOptions),
+            RecordedAtUtc = workflowEvent.RecordedAtUtc
+        };
+    }
+
+    private static WorkflowEventRecord ToEvent(WorkflowEventRecordEntry record)
+    {
+        List<WorkflowEventKey> keys = JsonSerializer.Deserialize<List<WorkflowEventKey>>(record.CorrelationKeysJson, JsonOptions) ?? [];
+        return new WorkflowEventRecord
+        {
+            Id = record.Id,
+            EventName = record.EventName,
+            CorrelationKeys = keys,
+            RecordedAtUtc = record.RecordedAtUtc
+        };
+    }
+
+    private static bool CorrelationKeysMatch(IReadOnlyCollection<WorkflowEventKey> expected, IReadOnlyCollection<WorkflowEventKey> actual)
+    {
+        if (expected.Count != actual.Count)
+        {
+            return false;
+        }
+
+        Dictionary<string, string> expectedMap = expected.ToDictionary(key => key.Key, key => key.Value, StringComparer.Ordinal);
+        foreach (WorkflowEventKey actualKey in actual)
+        {
+            if (!expectedMap.TryGetValue(actualKey.Key, out string? value) || value != actualKey.Value)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/GvatarWorkflow.EfCore/WorkflowDbContext.cs
+++ b/src/GvatarWorkflow.EfCore/WorkflowDbContext.cs
@@ -5,11 +5,17 @@ namespace GvatarWorkflow.Providers;
 public sealed class WorkflowDbContext(DbContextOptions<WorkflowDbContext> options) : DbContext(options)
 {
     public DbSet<WorkflowInstanceRecord> WorkflowInstances => Set<WorkflowInstanceRecord>();
+    public DbSet<WorkflowEventWaitRecord> WorkflowEventWaits => Set<WorkflowEventWaitRecord>();
+    public DbSet<WorkflowEventRecordEntry> WorkflowEvents => Set<WorkflowEventRecordEntry>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<WorkflowInstanceRecord>()
             .HasKey(instance => instance.Id);
+        modelBuilder.Entity<WorkflowEventWaitRecord>()
+            .HasKey(wait => wait.Id);
+        modelBuilder.Entity<WorkflowEventRecordEntry>()
+            .HasKey(evt => evt.Id);
     }
 }
 

--- a/src/GvatarWorkflow.EfCore/WorkflowEventRecords.cs
+++ b/src/GvatarWorkflow.EfCore/WorkflowEventRecords.cs
@@ -1,0 +1,20 @@
+namespace GvatarWorkflow.Providers;
+
+public sealed class WorkflowEventWaitRecord
+{
+    public Guid Id { get; set; }
+    public Guid WorkflowInstanceId { get; set; }
+    public Guid StepId { get; set; }
+    public string StepName { get; set; } = "";
+    public string EventName { get; set; } = "";
+    public string CorrelationKeysJson { get; set; } = "[]";
+    public DateTimeOffset CreatedAtUtc { get; set; }
+}
+
+public sealed class WorkflowEventRecordEntry
+{
+    public Guid Id { get; set; }
+    public string EventName { get; set; } = "";
+    public string CorrelationKeysJson { get; set; } = "[]";
+    public DateTimeOffset RecordedAtUtc { get; set; }
+}

--- a/src/GvatarWorkflow/Entities/Interfaces/IWorkflowOptions.cs
+++ b/src/GvatarWorkflow/Entities/Interfaces/IWorkflowOptions.cs
@@ -5,5 +5,6 @@ namespace GvatarWorkflow.Entities.Interfaces;
 public interface IWorkflowOptions
 {
     public void UsePersistenceProvider(Func<IServiceProvider, IPersistenceProvider> factory);
+    public void UseEventStore(Func<IServiceProvider, IWorkflowEventStore> factory);
     public void UseQueueProvider(Func<IServiceProvider, IQueueProvider> factory);
 }

--- a/src/GvatarWorkflow/Entities/WorkflowEvent.cs
+++ b/src/GvatarWorkflow/Entities/WorkflowEvent.cs
@@ -1,0 +1,22 @@
+namespace GvatarWorkflow.Entities;
+
+public sealed record WorkflowEventKey(string Key, string Value);
+
+public sealed class WorkflowEventWait
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid WorkflowInstanceId { get; set; }
+    public Guid StepId { get; set; }
+    public string StepName { get; set; } = "";
+    public string EventName { get; set; } = "";
+    public List<WorkflowEventKey> CorrelationKeys { get; set; } = [];
+    public DateTimeOffset CreatedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+}
+
+public sealed class WorkflowEventRecord
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string EventName { get; set; } = "";
+    public List<WorkflowEventKey> CorrelationKeys { get; set; } = [];
+    public DateTimeOffset RecordedAtUtc { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/src/GvatarWorkflow/Entities/WorkflowInstance.cs
+++ b/src/GvatarWorkflow/Entities/WorkflowInstance.cs
@@ -15,6 +15,4 @@ public class WorkflowInstance(
     public object? CurrentStepObjectContext { get; set; } = currentStepObjectContext;
     public WorkflowDefinition WorkflowDefinition { get; set; } = workflowDefinition;
     public List<ActivityInstance> ActivityInstances { get; set; } = activityInstances ?? [];
-    public TaskCompletionSource<bool>? TaskCompletionSource { get; set; } = null!;
-    public string? EventTriggerName { get; set; } = "";
 }

--- a/src/GvatarWorkflow/Entities/WorkflowOptions.cs
+++ b/src/GvatarWorkflow/Entities/WorkflowOptions.cs
@@ -9,6 +9,7 @@ namespace GvatarWorkflow.Entities;
 public class WorkflowOptions(IServiceCollection services) : IWorkflowOptions
 {
     public Func<IServiceProvider, IPersistenceProvider> PersistenceFactory = new(serviceProvider => new InMemoryPersistenceProvider(serviceProvider.GetService<SingletonInMemoryPersistenceProvider>() ?? throw new Exception("Workflow PersistenceProvider is required.")));
+    public Func<IServiceProvider, IWorkflowEventStore> EventStoreFactory = new(serviceProvider => new InMemoryWorkflowEventStore(serviceProvider.GetService<SingletonInMemoryWorkflowEventStore>() ?? throw new Exception("Workflow EventStore is required.")));
     public Func<IServiceProvider, IQueueProvider> QueueFactory = new(serviceProvider => new InMemoryQueueProvider(serviceProvider.GetService<IWorkflowExecutor>() ?? throw new Exception("Workflow Executor is required.")));
 
     public IServiceCollection Services { get; set; } = services;
@@ -16,6 +17,11 @@ public class WorkflowOptions(IServiceCollection services) : IWorkflowOptions
     public void UsePersistenceProvider(Func<IServiceProvider, IPersistenceProvider> factory)
     {
         PersistenceFactory = factory;
+    }
+
+    public void UseEventStore(Func<IServiceProvider, IWorkflowEventStore> factory)
+    {
+        EventStoreFactory = factory;
     }
 
     public void UseQueueProvider(Func<IServiceProvider, IQueueProvider> factory)

--- a/src/GvatarWorkflow/Providers/InMemoryWorkflowEventStore.cs
+++ b/src/GvatarWorkflow/Providers/InMemoryWorkflowEventStore.cs
@@ -1,0 +1,44 @@
+﻿using GvatarWorkflow.Entities;
+using GvatarWorkflow.Providers.Interfaces;
+
+namespace GvatarWorkflow.Providers;
+
+public sealed class InMemoryWorkflowEventStore(SingletonInMemoryWorkflowEventStore singletonInMemoryWorkflowEventStore) : IWorkflowEventStore
+{
+    private readonly SingletonInMemoryWorkflowEventStore _singletonInMemoryWorkflowEventStore = singletonInMemoryWorkflowEventStore;
+
+    public Task<WorkflowEventWait?> GetWaitForStep(Guid workflowInstanceId, Guid stepId)
+    {
+        return _singletonInMemoryWorkflowEventStore.GetWaitForStep(workflowInstanceId, stepId);
+    }
+
+    public Task<WorkflowEventWait> CreateWait(WorkflowEventWait wait)
+    {
+        return _singletonInMemoryWorkflowEventStore.CreateWait(wait);
+    }
+
+    public Task<IReadOnlyList<WorkflowEventWait>> GetWaitsByEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys)
+    {
+        return _singletonInMemoryWorkflowEventStore.GetWaitsByEvent(eventName, correlationKeys);
+    }
+
+    public Task RemoveWait(Guid waitId)
+    {
+        return _singletonInMemoryWorkflowEventStore.RemoveWait(waitId);
+    }
+
+    public Task<WorkflowEventRecord> RecordEvent(WorkflowEventRecord workflowEvent)
+    {
+        return _singletonInMemoryWorkflowEventStore.RecordEvent(workflowEvent);
+    }
+
+    public Task<WorkflowEventRecord?> FindMatchingEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys)
+    {
+        return _singletonInMemoryWorkflowEventStore.FindMatchingEvent(eventName, correlationKeys);
+    }
+
+    public Task RemoveEvent(Guid eventId)
+    {
+        return _singletonInMemoryWorkflowEventStore.RemoveEvent(eventId);
+    }
+}

--- a/src/GvatarWorkflow/Providers/Interfaces/IWorkflowEventStore.cs
+++ b/src/GvatarWorkflow/Providers/Interfaces/IWorkflowEventStore.cs
@@ -1,0 +1,14 @@
+﻿using GvatarWorkflow.Entities;
+
+namespace GvatarWorkflow.Providers.Interfaces;
+
+public interface IWorkflowEventStore
+{
+    public Task<WorkflowEventWait?> GetWaitForStep(Guid workflowInstanceId, Guid stepId);
+    public Task<WorkflowEventWait> CreateWait(WorkflowEventWait wait);
+    public Task<IReadOnlyList<WorkflowEventWait>> GetWaitsByEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys);
+    public Task RemoveWait(Guid waitId);
+    public Task<WorkflowEventRecord> RecordEvent(WorkflowEventRecord workflowEvent);
+    public Task<WorkflowEventRecord?> FindMatchingEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys);
+    public Task RemoveEvent(Guid eventId);
+}

--- a/src/GvatarWorkflow/Providers/SingletonInMemoryWorkflowEventStore.cs
+++ b/src/GvatarWorkflow/Providers/SingletonInMemoryWorkflowEventStore.cs
@@ -1,0 +1,105 @@
+﻿using GvatarWorkflow.Entities;
+using GvatarWorkflow.Providers.Interfaces;
+
+namespace GvatarWorkflow.Providers;
+
+public sealed class SingletonInMemoryWorkflowEventStore : IWorkflowEventStore
+{
+    private readonly List<WorkflowEventWait> _waits = [];
+    private readonly List<WorkflowEventRecord> _events = [];
+    private readonly object _lock = new();
+
+    public Task<WorkflowEventWait?> GetWaitForStep(Guid workflowInstanceId, Guid stepId)
+    {
+        lock (_lock)
+        {
+            return Task.FromResult(_waits.FirstOrDefault(wait => wait.WorkflowInstanceId == workflowInstanceId && wait.StepId == stepId));
+        }
+    }
+
+    public Task<WorkflowEventWait> CreateWait(WorkflowEventWait wait)
+    {
+        lock (_lock)
+        {
+            _waits.Add(wait);
+            return Task.FromResult(wait);
+        }
+    }
+
+    public Task<IReadOnlyList<WorkflowEventWait>> GetWaitsByEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys)
+    {
+        lock (_lock)
+        {
+            IReadOnlyList<WorkflowEventWait> waits = _waits
+                .Where(wait => wait.EventName == eventName && CorrelationKeysMatch(wait.CorrelationKeys, correlationKeys))
+                .ToList();
+            return Task.FromResult(waits);
+        }
+    }
+
+    public Task RemoveWait(Guid waitId)
+    {
+        lock (_lock)
+        {
+            WorkflowEventWait? existing = _waits.FirstOrDefault(wait => wait.Id == waitId);
+            if (existing is not null)
+            {
+                _waits.Remove(existing);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<WorkflowEventRecord> RecordEvent(WorkflowEventRecord workflowEvent)
+    {
+        lock (_lock)
+        {
+            _events.Add(workflowEvent);
+            return Task.FromResult(workflowEvent);
+        }
+    }
+
+    public Task<WorkflowEventRecord?> FindMatchingEvent(string eventName, IReadOnlyCollection<WorkflowEventKey> correlationKeys)
+    {
+        lock (_lock)
+        {
+            WorkflowEventRecord? match = _events
+                .FirstOrDefault(evt => evt.EventName == eventName && CorrelationKeysMatch(evt.CorrelationKeys, correlationKeys));
+            return Task.FromResult(match);
+        }
+    }
+
+    public Task RemoveEvent(Guid eventId)
+    {
+        lock (_lock)
+        {
+            WorkflowEventRecord? existing = _events.FirstOrDefault(evt => evt.Id == eventId);
+            if (existing is not null)
+            {
+                _events.Remove(existing);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static bool CorrelationKeysMatch(IReadOnlyCollection<WorkflowEventKey> expected, IReadOnlyCollection<WorkflowEventKey> actual)
+    {
+        if (expected.Count != actual.Count)
+        {
+            return false;
+        }
+
+        Dictionary<string, string> expectedMap = expected.ToDictionary(key => key.Key, key => key.Value, StringComparer.Ordinal);
+        foreach (WorkflowEventKey actualKey in actual)
+        {
+            if (!expectedMap.TryGetValue(actualKey.Key, out string? value) || value != actualKey.Value)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/GvatarWorkflow/ServiceCollectionExtension.cs
+++ b/src/GvatarWorkflow/ServiceCollectionExtension.cs
@@ -20,7 +20,9 @@ public static class ServiceCollectionExtension
         services.AddSingleton<IWorkflowExecutor, WorkflowExecutor>();
         services.AddScoped<IWorkflowDefinitionBuilder, WorkflowDefinitionBuilder>();
         services.AddSingleton<SingletonInMemoryPersistenceProvider>();
+        services.AddSingleton<SingletonInMemoryWorkflowEventStore>();
         services.AddTransient<IPersistenceProvider>(options.PersistenceFactory);
+        services.AddTransient<IWorkflowEventStore>(options.EventStoreFactory);
         services.AddSingleton<IQueueProvider>(options.QueueFactory);
         services.AddSingleton<DelegateContext>(serviceProvider =>
         {

--- a/src/GvatarWorkflow/Services/Interfaces/IWorkflowExecutor.cs
+++ b/src/GvatarWorkflow/Services/Interfaces/IWorkflowExecutor.cs
@@ -5,5 +5,5 @@ namespace GvatarWorkflow.Services.Interfaces;
 public interface IWorkflowExecutor
 {
     public Task ExecuteWorkflowInstance(Guid workflowInstanceId);
-    public Task ContinueWorkflowInstance(WorkflowInstance workflowInstance, string eventTriggerName);
+    public Task ContinueWorkflowInstance(string eventTriggerName, IReadOnlyCollection<WorkflowEventKey> correlationKeys);
 }

--- a/src/GvatarWorkflow/Services/WorkflowExecutor.cs
+++ b/src/GvatarWorkflow/Services/WorkflowExecutor.cs
@@ -2,13 +2,16 @@
 using GvatarWorkflow.Entities;
 using GvatarWorkflow.Providers.Interfaces;
 using GvatarWorkflow.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GvatarWorkflow.Services;
 
-public class WorkflowExecutor(IPersistenceProvider persistenceProvider, DelegateContext delegateContext) : IWorkflowExecutor
+public class WorkflowExecutor(IPersistenceProvider persistenceProvider, IWorkflowEventStore workflowEventStore, DelegateContext delegateContext, IServiceProvider serviceProvider) : IWorkflowExecutor
 {
     private readonly IPersistenceProvider _persistenceProvider = persistenceProvider;
+    private readonly IWorkflowEventStore _workflowEventStore = workflowEventStore;
     private readonly DelegateContext _delegateContext = delegateContext;
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
 
     public async Task ExecuteWorkflowInstance(Guid workflowInstanceId)
     {
@@ -24,27 +27,56 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
 
             foreach (Step step in currentStepsToExecute)
             {
-                ActivityInstance activityInstance = new(step.Id, step.Name)
+                ActivityInstance? activityInstance = currentWorkflowInstance.ActivityInstances
+                    .FirstOrDefault(instance => instance.StepId == step.Id && instance.Status == "Waiting");
+
+                if (activityInstance is null)
                 {
-                    Status = "In Progress",
-                    StartedAtUtc = DateTimeOffset.UtcNow,
-                    Attempt = 1
-                };
-                currentWorkflowInstance.ActivityInstances.Add(activityInstance);
-                await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                    activityInstance = new ActivityInstance(step.Id, step.Name)
+                    {
+                        Status = "In Progress",
+                        StartedAtUtc = DateTimeOffset.UtcNow,
+                        Attempt = 1
+                    };
+                    currentWorkflowInstance.ActivityInstances.Add(activityInstance);
+                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                }
 
                 if (step.WaitFor is not null)
                 {
-                    currentWorkflowInstance.Status = "Waiting";
-                    currentWorkflowInstance.TaskCompletionSource = new TaskCompletionSource<bool>();
-                    currentWorkflowInstance.EventTriggerName = step.WaitFor?.Item1;
-                    activityInstance.Status = "Waiting";
-                    activityInstance.WaitingForEvent = step.WaitFor?.Item1;
-                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
-                    await currentWorkflowInstance.TaskCompletionSource.Task; // Waits for this task to complete before continuing
+                    string eventName = step.WaitFor.Value.Item1;
+                    IReadOnlyCollection<WorkflowEventKey> correlationKeys = BuildCorrelationKeys(currentWorkflowInstance);
+
+                    WorkflowEventWait? existingWait = await _workflowEventStore.GetWaitForStep(currentWorkflowInstance.Id, step.Id);
+                    WorkflowEventWait wait = existingWait ?? new WorkflowEventWait
+                    {
+                        WorkflowInstanceId = currentWorkflowInstance.Id,
+                        StepId = step.Id,
+                        StepName = step.Name,
+                        EventName = eventName,
+                        CorrelationKeys = correlationKeys.ToList()
+                    };
+
+                    if (existingWait is null)
+                    {
+                        await _workflowEventStore.CreateWait(wait);
+                    }
+
+                    WorkflowEventRecord? matchingEvent = await _workflowEventStore.FindMatchingEvent(eventName, wait.CorrelationKeys);
+                    if (matchingEvent is null)
+                    {
+                        currentWorkflowInstance.Status = "Waiting";
+                        activityInstance.Status = "Waiting";
+                        activityInstance.WaitingForEvent = eventName;
+                        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                        return;
+                    }
+
+                    await _workflowEventStore.RemoveEvent(matchingEvent.Id);
+                    await _workflowEventStore.RemoveWait(wait.Id);
                     activityInstance.Status = "In Progress";
                     activityInstance.WaitingForEvent = null;
-                    step.WaitFor?.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
+                    step.WaitFor.Value.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
                     currentWorkflowInstance.Status = "In Progress";
                     await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
                 }
@@ -83,21 +115,26 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
         await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
     }
 
-    public Task ContinueWorkflowInstance(WorkflowInstance workflowInstance, string eventTriggerName)
+    public async Task ContinueWorkflowInstance(string eventTriggerName, IReadOnlyCollection<WorkflowEventKey> correlationKeys)
     {
-        Task.Run(() =>
+        WorkflowEventRecord workflowEvent = new()
         {
-            if (workflowInstance.EventTriggerName == eventTriggerName)
-            {
-                Console.WriteLine($"Continuing workflow for event: {eventTriggerName}");
-                workflowInstance.TaskCompletionSource?.TrySetResult(true);
-            }
-            else
-            {
-                Console.WriteLine($"No matching event found for: {eventTriggerName}. Expecting {workflowInstance.EventTriggerName}");
-            }
-        });
+            EventName = eventTriggerName,
+            CorrelationKeys = correlationKeys.ToList()
+        };
 
-        return Task.CompletedTask;
+        await _workflowEventStore.RecordEvent(workflowEvent);
+
+        IReadOnlyList<WorkflowEventWait> waits = await _workflowEventStore.GetWaitsByEvent(eventTriggerName, correlationKeys);
+        IQueueProvider queueProvider = _serviceProvider.GetRequiredService<IQueueProvider>();
+        foreach (WorkflowEventWait wait in waits)
+        {
+            await queueProvider.QueueWork(wait.WorkflowInstanceId, QueueType.Workflow);
+        }
+    }
+
+    private static IReadOnlyCollection<WorkflowEventKey> BuildCorrelationKeys(WorkflowInstance workflowInstance)
+    {
+        return [new WorkflowEventKey("workflowInstanceId", workflowInstance.Id.ToString())];
     }
 }

--- a/src/Sample2/Controllers/SimpleWorkflowController.cs
+++ b/src/Sample2/Controllers/SimpleWorkflowController.cs
@@ -81,9 +81,12 @@ public class SimpleWorkflowController(ILogger<SimpleWorkflowController> logger, 
     [HttpGet("TriggerEvent")]
     public async Task TriggerEvent([FromQuery] Guid workflowInstanceId,[FromQuery] string eventTriggerName)
     {
-        WorkflowInstance workflowInstance = await _workflowService.GetWorkflowInstanceById(workflowInstanceId);
-        await _workflowExecutor.ContinueWorkflowInstance(workflowInstance, eventTriggerName);
+        // This endpoint can be called from another process or node to resume a waiting workflow.
+        WorkflowEventKey[] correlationKeys =
+        [
+            new WorkflowEventKey("workflowInstanceId", workflowInstanceId.ToString())
+        ];
 
-        return;
+        await _workflowExecutor.ContinueWorkflowInstance(eventTriggerName, correlationKeys);
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the ephemeral `TaskCompletionSource` wait model with a durable, persisted wait so workflows can resume after process restarts or on other nodes.
- Support correlated event delivery so `ContinueWorkflowInstance` calls can resume the exact waiting activity using correlation keys (defaulting to `workflowInstanceId`).
- Provide a storage abstraction for events/waits so different persistence backends (in-memory or EF Core) can be used.

### Description
- Introduced event domain types `WorkflowEventKey`, `WorkflowEventWait`, and `WorkflowEventRecord` in `Entities` and added `IWorkflowEventStore` with in-memory (`SingletonInMemoryWorkflowEventStore` + `InMemoryWorkflowEventStore`) and EF Core (`EntityFrameworkWorkflowEventStore`) implementations and DB records in `GvatarWorkflow.EfCore`.
- Reworked `WorkflowExecutor` to persist wait state via `IWorkflowEventStore`, stop using `TaskCompletionSource`, return control when a step is waiting, and resume execution when a matching event is recorded; `ContinueWorkflowInstance` now records an event and enqueues matching workflow instances by correlation keys.
- Added event store wiring to DI and options: `WorkflowOptions` got `EventStoreFactory`, `ServiceCollectionExtension` registers the event store, and `IWorkflowExecutor.ContinueWorkflowInstance` signature changed to accept `eventTriggerName` + correlation keys.
- Updated the sample controller `TriggerEvent` usage and README docs to demonstrate correlation keys and durable behavior (posting events from another process/node).

### Testing
- No automated tests were run on the modified code.
- No unit or integration tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f22d65c3883329cea669ed86bd247)