### PR TITLE
Add transition-based workflow routing with retry and compensation

### DIFF
--- a/src/GvatarWorkflow.EfCore/WorkflowDefinitionRecord.cs
+++ b/src/GvatarWorkflow.EfCore/WorkflowDefinitionRecord.cs
@@ -37,17 +37,19 @@ public sealed class WorkflowDefinitionRecord
 
 public sealed class StepRecord
 {
+    public Guid Id { get; set; }
     public string Name { get; set; } = "";
     public string FunctionDelegateName { get; set; } = "";
-    public List<string>? ChildrenSteps { get; set; }
+    public List<TransitionRecord> Transitions { get; set; } = [];
 
     public static StepRecord FromStep(Step step)
     {
         return new StepRecord
         {
+            Id = step.Id,
             Name = step.Name,
             FunctionDelegateName = step.FunctionDelegateName,
-            ChildrenSteps = step.ChildrenSteps?.ToList()
+            Transitions = step.Transitions.Select(TransitionRecord.FromTransition).ToList()
         };
     }
 
@@ -55,9 +57,97 @@ public sealed class StepRecord
     {
         return new Step
         {
+            Id = Id,
             Name = Name,
             FunctionDelegateName = FunctionDelegateName,
-            ChildrenSteps = ChildrenSteps
+            Transitions = Transitions.Select(transition => transition.ToTransition()).ToList()
+        };
+    }
+}
+
+public sealed class TransitionRecord
+{
+    public Guid Id { get; set; }
+    public Guid FromStepId { get; set; }
+    public Guid ToStepId { get; set; }
+    public TransitionConditionRecord? Condition { get; set; }
+    public RetryPolicyRecord? RetryPolicy { get; set; }
+    public Guid? CompensationStepId { get; set; }
+    public bool OnFailure { get; set; }
+    public int Order { get; set; }
+
+    public static TransitionRecord FromTransition(Transition transition)
+    {
+        return new TransitionRecord
+        {
+            Id = transition.Id,
+            FromStepId = transition.FromStepId,
+            ToStepId = transition.ToStepId,
+            Condition = transition.Condition is null ? null : TransitionConditionRecord.FromCondition(transition.Condition),
+            RetryPolicy = transition.RetryPolicy is null ? null : RetryPolicyRecord.FromPolicy(transition.RetryPolicy),
+            CompensationStepId = transition.CompensationStepId,
+            OnFailure = transition.OnFailure,
+            Order = transition.Order
+        };
+    }
+
+    public Transition ToTransition()
+    {
+        return new Transition
+        {
+            Id = Id,
+            FromStepId = FromStepId,
+            ToStepId = ToStepId,
+            Condition = Condition?.ToCondition(),
+            RetryPolicy = RetryPolicy?.ToPolicy(),
+            CompensationStepId = CompensationStepId,
+            OnFailure = OnFailure,
+            Order = Order
+        };
+    }
+}
+
+public sealed class TransitionConditionRecord
+{
+    public TransitionConditionType Type { get; set; } = TransitionConditionType.Always;
+    public string? Value { get; set; }
+
+    public static TransitionConditionRecord FromCondition(TransitionCondition condition)
+    {
+        return new TransitionConditionRecord
+        {
+            Type = condition.Type,
+            Value = condition.Value
+        };
+    }
+
+    public TransitionCondition ToCondition()
+    {
+        return new TransitionCondition
+        {
+            Type = Type,
+            Value = Value
+        };
+    }
+}
+
+public sealed class RetryPolicyRecord
+{
+    public int MaxAttempts { get; set; }
+
+    public static RetryPolicyRecord FromPolicy(RetryPolicy retryPolicy)
+    {
+        return new RetryPolicyRecord
+        {
+            MaxAttempts = retryPolicy.MaxAttempts
+        };
+    }
+
+    public RetryPolicy ToPolicy()
+    {
+        return new RetryPolicy
+        {
+            MaxAttempts = MaxAttempts
         };
     }
 }

--- a/src/GvatarWorkflow/Entities/ActivityInstance.cs
+++ b/src/GvatarWorkflow/Entities/ActivityInstance.cs
@@ -7,6 +7,11 @@ public class ActivityInstance(Guid stepId, string stepName)
     public string StepName { get; set; } = stepName;
     public string Status { get; set; } = "Pending";
     public int Attempt { get; set; } = 0;
+    public int CompensationAttempt { get; set; } = 0;
+    public Guid? CompensationStepId { get; set; }
+    public DateTimeOffset? CompensationScheduledAtUtc { get; set; }
+    public DateTimeOffset? CompensationCompletedAtUtc { get; set; }
+    public bool CompensationExecuted { get; set; }
     public DateTimeOffset? StartedAtUtc { get; set; }
     public DateTimeOffset? CompletedAtUtc { get; set; }
     public string? WaitingForEvent { get; set; }

--- a/src/GvatarWorkflow/Entities/Interfaces/IStep.cs
+++ b/src/GvatarWorkflow/Entities/Interfaces/IStep.cs
@@ -1,6 +1,0 @@
-﻿namespace GvatarWorkflow.Entities.Interfaces;
-
-public interface IStep
-{
-    public bool ShouldRun();
-}

--- a/src/GvatarWorkflow/Entities/Step.cs
+++ b/src/GvatarWorkflow/Entities/Step.cs
@@ -1,17 +1,10 @@
-﻿using GvatarWorkflow.Entities.Interfaces;
+﻿namespace GvatarWorkflow.Entities;
 
-namespace GvatarWorkflow.Entities;
-
-public class Step : IStep
+public class Step
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public string Name { get; set; } = "";
     public string FunctionDelegateName { get; set; } = "";
-    public List<Guid>? ChildrenSteps { get; set; } = [];
-    public Func<object?, bool>? Condition { get; set; } = (_) => true;
+    public List<Transition> Transitions { get; set; } = [];
     public (string, Func<object?, bool>)? WaitFor { get; set; }
-    public bool ShouldRun()
-    {
-        return Condition is not null && Condition(null);
-    }
 }

--- a/src/GvatarWorkflow/Entities/Transition.cs
+++ b/src/GvatarWorkflow/Entities/Transition.cs
@@ -1,0 +1,109 @@
+namespace GvatarWorkflow.Entities;
+
+public enum TransitionConditionType
+{
+    Always,
+    OutputTrue,
+    OutputFalse,
+    Equals,
+    NotEquals,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual
+}
+
+public class TransitionCondition
+{
+    public TransitionConditionType Type { get; set; } = TransitionConditionType.Always;
+    public string? Value { get; set; }
+
+    public bool Evaluate(object? input)
+    {
+        switch (Type)
+        {
+            case TransitionConditionType.Always:
+                return true;
+            case TransitionConditionType.OutputTrue:
+                return input is bool trueValue && trueValue;
+            case TransitionConditionType.OutputFalse:
+                return input is bool falseValue && !falseValue;
+            case TransitionConditionType.Equals:
+                return string.Equals(Value, input?.ToString(), StringComparison.OrdinalIgnoreCase);
+            case TransitionConditionType.NotEquals:
+                return !string.Equals(Value, input?.ToString(), StringComparison.OrdinalIgnoreCase);
+            case TransitionConditionType.GreaterThan:
+                return CompareNumeric(input, Value, comparison => comparison > 0);
+            case TransitionConditionType.GreaterThanOrEqual:
+                return CompareNumeric(input, Value, comparison => comparison >= 0);
+            case TransitionConditionType.LessThan:
+                return CompareNumeric(input, Value, comparison => comparison < 0);
+            case TransitionConditionType.LessThanOrEqual:
+                return CompareNumeric(input, Value, comparison => comparison <= 0);
+            default:
+                return false;
+        }
+    }
+
+    private static bool CompareNumeric(object? input, string? value, Func<int, bool> predicate)
+    {
+        if (!TryConvertToDecimal(input, out decimal inputDecimal))
+        {
+            return false;
+        }
+
+        if (!TryConvertToDecimal(value, out decimal valueDecimal))
+        {
+            return false;
+        }
+
+        return predicate(inputDecimal.CompareTo(valueDecimal));
+    }
+
+    private static bool TryConvertToDecimal(object? value, out decimal result)
+    {
+        result = default;
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (value is decimal decimalValue)
+        {
+            result = decimalValue;
+            return true;
+        }
+
+        if (value is IConvertible)
+        {
+            try
+            {
+                result = Convert.ToDecimal(value);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        return decimal.TryParse(value.ToString(), out result);
+    }
+}
+
+public class RetryPolicy
+{
+    public int MaxAttempts { get; set; } = 1;
+}
+
+public class Transition
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid FromStepId { get; set; }
+    public Guid ToStepId { get; set; }
+    public TransitionCondition? Condition { get; set; } = new();
+    public RetryPolicy? RetryPolicy { get; set; }
+    public Guid? CompensationStepId { get; set; }
+    public bool OnFailure { get; set; }
+    public int Order { get; set; }
+}

--- a/src/GvatarWorkflow/Services/WorkflowExecutor.cs
+++ b/src/GvatarWorkflow/Services/WorkflowExecutor.cs
@@ -33,49 +33,65 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
                 currentWorkflowInstance.ActivityInstances.Add(activityInstance);
                 await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
 
-                if (step.WaitFor is not null)
+                bool stepCompleted = false;
+                while (!stepCompleted)
                 {
-                    currentWorkflowInstance.Status = "Waiting";
-                    currentWorkflowInstance.TaskCompletionSource = new TaskCompletionSource<bool>();
-                    currentWorkflowInstance.EventTriggerName = step.WaitFor?.Item1;
-                    activityInstance.Status = "Waiting";
-                    activityInstance.WaitingForEvent = step.WaitFor?.Item1;
-                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
-                    await currentWorkflowInstance.TaskCompletionSource.Task; // Waits for this task to complete before continuing
-                    activityInstance.Status = "In Progress";
-                    activityInstance.WaitingForEvent = null;
-                    step.WaitFor?.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
-                    currentWorkflowInstance.Status = "In Progress";
-                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
-                }
-
-                try
-                {
-                    var output = _delegateContext.InvokeDelegate(step.FunctionDelegateName, currentWorkflowInstance.CurrentStepObjectContext, step.Condition);
-                    currentWorkflowInstance.CurrentStepObjectContext = output;
-                    currentWorkflowInstance.PreviousCompletedStepIds.Add(step.Id);
-                    currentWorkflowInstance.NextPendingStepIds.Remove(step.Id);
-                    activityInstance.Output = output;
-                    activityInstance.Status = "Completed";
-                    activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
-
-                    if (step.ChildrenSteps is not null)
+                    if (step.WaitFor is not null)
                     {
-                        currentWorkflowInstance.NextPendingStepIds.AddRange(step.ChildrenSteps);
-                        currentWorkflowInstance.NextPendingStepIds = currentWorkflowInstance.NextPendingStepIds.Distinct().ToList();
+                        currentWorkflowInstance.Status = "Waiting";
+                        currentWorkflowInstance.TaskCompletionSource = new TaskCompletionSource<bool>();
+                        currentWorkflowInstance.EventTriggerName = step.WaitFor?.Item1;
+                        activityInstance.Status = "Waiting";
+                        activityInstance.WaitingForEvent = step.WaitFor?.Item1;
+                        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                        await currentWorkflowInstance.TaskCompletionSource.Task; // Waits for this task to complete before continuing
+                        activityInstance.Status = "In Progress";
+                        activityInstance.WaitingForEvent = null;
+                        step.WaitFor?.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
+                        currentWorkflowInstance.Status = "In Progress";
+                        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
                     }
-                }
-                catch (Exception ex)
-                {
-                    activityInstance.Status = "Failed";
-                    activityInstance.ErrorMessage = ex.Message;
-                    activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
-                    currentWorkflowInstance.Status = "Failed";
-                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
-                    throw;
-                }
 
-                await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                    try
+                    {
+                        var output = _delegateContext.InvokeDelegate(step.FunctionDelegateName, currentWorkflowInstance.CurrentStepObjectContext);
+                        currentWorkflowInstance.CurrentStepObjectContext = output;
+                        currentWorkflowInstance.PreviousCompletedStepIds.Add(step.Id);
+                        currentWorkflowInstance.NextPendingStepIds.Remove(step.Id);
+                        activityInstance.Output = output;
+                        activityInstance.Status = "Completed";
+                        activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
+
+                        MarkCompensationComplete(currentWorkflowInstance, step.Id);
+                        EnqueueTransitions(step, currentWorkflowInstance, output, onFailure: false);
+                        stepCompleted = true;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (TryScheduleRetry(step, currentWorkflowInstance, activityInstance, ex))
+                        {
+                            await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                            continue;
+                        }
+
+                        activityInstance.Status = "Failed";
+                        activityInstance.ErrorMessage = ex.Message;
+                        activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
+                        currentWorkflowInstance.NextPendingStepIds.Remove(step.Id);
+
+                        bool scheduledFailureTransitions = EnqueueTransitions(step, currentWorkflowInstance, currentWorkflowInstance.CurrentStepObjectContext, onFailure: true);
+                        if (!scheduledFailureTransitions)
+                        {
+                            currentWorkflowInstance.Status = "Failed";
+                            await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                            throw;
+                        }
+
+                        stepCompleted = true;
+                    }
+
+                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                }
             }
         }
 
@@ -99,5 +115,71 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, Delegate
         });
 
         return Task.CompletedTask;
+    }
+
+    private static void MarkCompensationComplete(WorkflowInstance workflowInstance, Guid compensationStepId)
+    {
+        foreach (ActivityInstance activityInstance in workflowInstance.ActivityInstances
+                     .Where(instance => instance.CompensationStepId == compensationStepId && !instance.CompensationExecuted))
+        {
+            activityInstance.CompensationExecuted = true;
+            activityInstance.CompensationCompletedAtUtc = DateTimeOffset.UtcNow;
+        }
+    }
+
+    private static IEnumerable<Transition> GetOrderedTransitions(Step step, bool onFailure)
+    {
+        return step.Transitions
+            .Where(transition => transition.OnFailure == onFailure && transition.FromStepId == step.Id)
+            .OrderBy(transition => transition.Order)
+            .ThenBy(transition => transition.ToStepId);
+    }
+
+    private static bool EnqueueTransitions(Step step, WorkflowInstance workflowInstance, object? output, bool onFailure)
+    {
+        IEnumerable<Transition> transitions = GetOrderedTransitions(step, onFailure)
+            .Where(transition => transition.Condition?.Evaluate(output) ?? true);
+        bool hasTransitions = false;
+
+        foreach (Transition transition in transitions)
+        {
+            hasTransitions = true;
+            workflowInstance.NextPendingStepIds.Add(transition.ToStepId);
+            if (transition.CompensationStepId is not null)
+            {
+                workflowInstance.NextPendingStepIds.Add(transition.CompensationStepId.Value);
+                ActivityInstance? failedInstance = workflowInstance.ActivityInstances.LastOrDefault(instance => instance.StepId == step.Id);
+                if (failedInstance is not null && failedInstance.CompensationStepId is null)
+                {
+                    failedInstance.CompensationStepId = transition.CompensationStepId;
+                    failedInstance.CompensationAttempt = 1;
+                    failedInstance.CompensationScheduledAtUtc = DateTimeOffset.UtcNow;
+                }
+            }
+        }
+
+        workflowInstance.NextPendingStepIds = workflowInstance.NextPendingStepIds.Distinct().ToList();
+        return hasTransitions;
+    }
+
+    private static bool TryScheduleRetry(Step step, WorkflowInstance workflowInstance, ActivityInstance activityInstance, Exception exception)
+    {
+        Transition? retryTransition = GetOrderedTransitions(step, onFailure: true)
+            .FirstOrDefault(transition => transition.RetryPolicy is not null
+                                          && activityInstance.Attempt < transition.RetryPolicy.MaxAttempts
+                                          && transition.ToStepId == step.Id
+                                          && (transition.Condition?.Evaluate(workflowInstance.CurrentStepObjectContext) ?? true));
+
+        if (retryTransition is null)
+        {
+            return false;
+        }
+
+        activityInstance.Attempt += 1;
+        activityInstance.Status = "Retrying";
+        activityInstance.ErrorMessage = exception.Message;
+        workflowInstance.NextPendingStepIds.Add(retryTransition.ToStepId);
+        workflowInstance.NextPendingStepIds = workflowInstance.NextPendingStepIds.Distinct().ToList();
+        return true;
     }
 }

--- a/src/Sample1/Controllers/SimpleWorkflowController.cs
+++ b/src/Sample1/Controllers/SimpleWorkflowController.cs
@@ -1,5 +1,4 @@
 using GvatarWorkflow.Entities;
-using GvatarWorkflow.Entities.Interfaces;
 using GvatarWorkflow.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,35 +20,73 @@ public class SimpleWorkflowController(ILogger<SimpleWorkflowController> logger, 
         Step step1 = new()
         {
             Name = "Step1",
-            FunctionDelegateName = "HelloWorldDelegate",
-            Condition = null
+            FunctionDelegateName = "HelloWorldDelegate"
         };
 
         Step step2a = new()
         {
             Name = "Step2a",
-            FunctionDelegateName = "MiddleDelegate",
-            Condition = null
+            FunctionDelegateName = "MiddleDelegate"
         };
 
         Step step2b = new()
         {
             Name = "Step2b",
-            FunctionDelegateName = "MiddleDelegate2",
-            Condition = (input) => ((int?)input > 1)
+            FunctionDelegateName = "MiddleDelegate2"
         };
 
         Step step3 = new()
         {
             Name = "Step3",
             FunctionDelegateName = "EndWorkflowDelegate",
-            ChildrenSteps = null,
-            Condition = null
+            Transitions = []
         };
 
-        step1.ChildrenSteps = [step2a.Id, step2b.Id];
-        step2a.ChildrenSteps = [step3.Id];
-        step2b.ChildrenSteps = [step3.Id];
+        step1.Transitions =
+        [
+            new Transition
+            {
+                FromStepId = step1.Id,
+                ToStepId = step2a.Id,
+                Condition = new TransitionCondition
+                {
+                    Type = TransitionConditionType.LessThanOrEqual,
+                    Value = "1"
+                },
+                Order = 1
+            },
+            new Transition
+            {
+                FromStepId = step1.Id,
+                ToStepId = step2b.Id,
+                Condition = new TransitionCondition
+                {
+                    Type = TransitionConditionType.GreaterThan,
+                    Value = "1"
+                },
+                Order = 2
+            }
+        ];
+        step2a.Transitions =
+        [
+            new Transition
+            {
+                FromStepId = step2a.Id,
+                ToStepId = step3.Id,
+                Condition = new TransitionCondition { Type = TransitionConditionType.Always },
+                Order = 1
+            }
+        ];
+        step2b.Transitions =
+        [
+            new Transition
+            {
+                FromStepId = step2b.Id,
+                ToStepId = step3.Id,
+                Condition = new TransitionCondition { Type = TransitionConditionType.Always },
+                Order = 1
+            }
+        ];
 
         WorkflowDefinition simpleWorkflowDefinition =
             _workflowDefinitionBuilder

--- a/src/Sample2/Controllers/SimpleWorkflowController.cs
+++ b/src/Sample2/Controllers/SimpleWorkflowController.cs
@@ -1,5 +1,4 @@
 using GvatarWorkflow.Entities;
-using GvatarWorkflow.Entities.Interfaces;
 using GvatarWorkflow.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -23,7 +22,6 @@ public class SimpleWorkflowController(ILogger<SimpleWorkflowController> logger, 
         {
             Name = "Step1",
             FunctionDelegateName = "HelloWorldDelegate",
-            Condition = null,
             WaitFor = null
         };
 
@@ -31,7 +29,6 @@ public class SimpleWorkflowController(ILogger<SimpleWorkflowController> logger, 
         {
             Name = "Step2a",
             FunctionDelegateName = "MiddleDelegate",
-            Condition = null,
             WaitFor = ("event1", (_) => {
                 Console.WriteLine("event1 completed");
                 return true;
@@ -42,7 +39,6 @@ public class SimpleWorkflowController(ILogger<SimpleWorkflowController> logger, 
         {
             Name = "Step2b",
             FunctionDelegateName = "MiddleDelegate2",
-            Condition = (input) => ((int?)input > 1),
             WaitFor = null
         };
 
@@ -50,14 +46,55 @@ public class SimpleWorkflowController(ILogger<SimpleWorkflowController> logger, 
         {
             Name = "Step3",
             FunctionDelegateName = "EndWorkflowDelegate",
-            ChildrenSteps = null,
-            Condition = null,
+            Transitions = [],
             WaitFor = null
         };
 
-        step1.ChildrenSteps = [step2a.Id, step2b.Id];
-        step2a.ChildrenSteps = [step3.Id];
-        step2b.ChildrenSteps = [step3.Id];
+        step1.Transitions =
+        [
+            new Transition
+            {
+                FromStepId = step1.Id,
+                ToStepId = step2a.Id,
+                Condition = new TransitionCondition
+                {
+                    Type = TransitionConditionType.LessThanOrEqual,
+                    Value = "1"
+                },
+                Order = 1
+            },
+            new Transition
+            {
+                FromStepId = step1.Id,
+                ToStepId = step2b.Id,
+                Condition = new TransitionCondition
+                {
+                    Type = TransitionConditionType.GreaterThan,
+                    Value = "1"
+                },
+                Order = 2
+            }
+        ];
+        step2a.Transitions =
+        [
+            new Transition
+            {
+                FromStepId = step2a.Id,
+                ToStepId = step3.Id,
+                Condition = new TransitionCondition { Type = TransitionConditionType.Always },
+                Order = 1
+            }
+        ];
+        step2b.Transitions =
+        [
+            new Transition
+            {
+                FromStepId = step2b.Id,
+                ToStepId = step3.Id,
+                Condition = new TransitionCondition { Type = TransitionConditionType.Always },
+                Order = 1
+            }
+        ];
 
         WorkflowDefinition simpleWorkflowDefinition =
             _workflowDefinitionBuilder


### PR DESCRIPTION
### Motivation
- Replace the simple `ChildrenSteps` list with a richer, explicit transition model so routing is deterministic and inspectable.
- Move conditional logic from steps to transitions so branching outcomes are explicit and reusable as `TransitionCondition` rules.
- Introduce retry and compensation metadata so failed activities can schedule retries or compensation steps instead of immediately failing the workflow.
- Persist transition definitions so transition rules survive restarts via the existing EF Core pattern in `WorkflowDefinitionRecord`.

### Description
- Introduced `Transition`, `TransitionCondition`, `TransitionConditionType`, and `RetryPolicy` in `src/GvatarWorkflow/Entities/Transition.cs` and replaced `Step.ChildrenSteps` with `Step.Transitions` in `src/GvatarWorkflow/Entities/Step.cs`.
- Extended `ActivityInstance` with compensation tracking fields (`CompensationAttempt`, `CompensationStepId`, scheduling/completion timestamps, and `CompensationExecuted`) in `src/GvatarWorkflow/Entities/ActivityInstance.cs`.
- Updated the executor loop in `WorkflowExecutor.ExecuteWorkflowInstance` to evaluate transitions rather than blindly enqueueing child IDs, added helper methods `EnqueueTransitions`, `TryScheduleRetry`, and `MarkCompensationComplete`, and wired retry/compensation behavior in `src/GvatarWorkflow/Services/WorkflowExecutor.cs`.
- Persisted transition records in EF Core by adding `TransitionRecord`, `TransitionConditionRecord`, and `RetryPolicyRecord` and mapping `StepRecord.Transitions` in `src/GvatarWorkflow.EfCore/WorkflowDefinitionRecord.cs`, and updated sample controllers to define transitions instead of child lists.

### Testing
- No automated tests were run as part of this change.
- Manual verification recommended: build and run sample workflows to validate branching, retry, compensation, and persistence behavior using `WorkflowExecutor` and updated sample controllers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f22da29808332ac7a1f00cb447a56)