### PR TITLE
Scope workflow services and create per-job service scope in InMemoryQueueProvider

### DIFF
--- a/src/GvatarWorkflow/Providers/InMemoryQueueProvider.cs
+++ b/src/GvatarWorkflow/Providers/InMemoryQueueProvider.cs
@@ -1,12 +1,13 @@
 ﻿using GvatarWorkflow.Providers.Interfaces;
 using GvatarWorkflow.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Concurrent;
 
 namespace GvatarWorkflow.Providers;
 
-public class InMemoryQueueProvider(IWorkflowExecutor workflowExecutor) : IQueueProvider
+public class InMemoryQueueProvider(IServiceScopeFactory scopeFactory) : IQueueProvider
 {
-    private readonly IWorkflowExecutor _workflowExecutor = workflowExecutor;
+    private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
     public Dictionary<QueueType, BlockingCollection<Guid>> _queues = new()
     {
         [QueueType.Workflow] = [],
@@ -34,7 +35,9 @@ public class InMemoryQueueProvider(IWorkflowExecutor workflowExecutor) : IQueueP
             {
                 foreach (var job in queue.GetConsumingEnumerable())
                 {
-                    await _workflowExecutor.ExecuteWorkflowInstance(job);
+                    using IServiceScope scope = _scopeFactory.CreateScope();
+                    IWorkflowExecutor workflowExecutor = scope.ServiceProvider.GetRequiredService<IWorkflowExecutor>();
+                    await workflowExecutor.ExecuteWorkflowInstance(job);
                 }
             })
             {

--- a/src/GvatarWorkflow/ServiceCollectionExtension.cs
+++ b/src/GvatarWorkflow/ServiceCollectionExtension.cs
@@ -16,8 +16,8 @@ public static class ServiceCollectionExtension
         WorkflowOptions options = new(services);
         configureActions?.Invoke(options);
 
-        services.AddSingleton<IWorkflowService, WorkflowService>();
-        services.AddSingleton<IWorkflowExecutor, WorkflowExecutor>();
+        services.AddScoped<IWorkflowService, WorkflowService>();
+        services.AddScoped<IWorkflowExecutor, WorkflowExecutor>();
         services.AddScoped<IWorkflowDefinitionBuilder, WorkflowDefinitionBuilder>();
         services.AddSingleton<SingletonInMemoryPersistenceProvider>();
         services.AddSingleton<SingletonInMemoryWorkflowEventStore>();


### PR DESCRIPTION
### Motivation
- Ensure scoped dependencies (e.g. EntityFramework `WorkflowDbContext`) are resolved inside an appropriate scope instead of being captured by singletons.
- Prevent capturing a scoped `IWorkflowExecutor` in a singleton queue provider which can cause incorrect lifetime usage.
- Keep `IQueueProvider` as a singleton to manage background threads while making per-job execution scoped.
- Allow `IPersistenceProvider` (transient/scoped) to be resolved within a request/job scope so DB contexts are created and disposed correctly.

### Description
- Change `AddGvatarWorkflow` to register `IWorkflowService` and `IWorkflowExecutor` with `AddScoped` instead of `AddSingleton`.
- Modify `InMemoryQueueProvider` to accept an `IServiceScopeFactory` in its constructor and store it as `_scopeFactory`.
- Update `InMemoryQueueProvider.Start()` to create an `IServiceScope` per dequeued job and resolve `IWorkflowExecutor` via `scope.ServiceProvider.GetRequiredService<IWorkflowExecutor>()` before calling `ExecuteWorkflowInstance`.
- Add `using Microsoft.Extensions.DependencyInjection;` to the provider and keep the `IQueueProvider` registration unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4afc571483328b1bebe510261b8e)