### PR TITLE
Fix workflow execution safety, delegate resolution, and default wiring

### DIFF
--- a/src/GvatarWorkflow/Context/DelegateContext.cs
+++ b/src/GvatarWorkflow/Context/DelegateContext.cs
@@ -28,11 +28,20 @@ public class DelegateContext
 
     public object? InvokeDelegate(string delegateName, object? input, Func<object?, bool>? condition)
     {
+        if (_types is null)
+        {
+            throw new InvalidOperationException("DelegateContext has not been initialized. Call InitialPopulationOfAssemblyTypes first.");
+        }
+
         if (condition == null || condition(input))
         {
-            Type? delegateToInvoke = _types?
-                                    .Where(type => type.Name == delegateName).First();
-            object? delegateInstance = (delegateToInvoke is not null) ? Activator.CreateInstance(delegateToInvoke) : null;
+            Type? delegateToInvoke = _types.FirstOrDefault(type => type.Name == delegateName);
+            if (delegateToInvoke is null)
+            {
+                throw new InvalidOperationException($"Delegate '{delegateName}' was not found. Ensure it is loaded and implements {nameof(IDelegate)}.");
+            }
+
+            object? delegateInstance = Activator.CreateInstance(delegateToInvoke);
             MethodInfo? executeMethod = delegateToInvoke?.GetMethod("Execute");
             return executeMethod?.Invoke(delegateInstance, [input]);
         }

--- a/src/GvatarWorkflow/Entities/Interfaces/IStep.cs
+++ b/src/GvatarWorkflow/Entities/Interfaces/IStep.cs
@@ -2,5 +2,5 @@
 
 public interface IStep
 {
-    public bool ShouldRun();
+    public bool ShouldRun(object? input);
 }

--- a/src/GvatarWorkflow/Entities/Step.cs
+++ b/src/GvatarWorkflow/Entities/Step.cs
@@ -10,8 +10,8 @@ public class Step : IStep
     public List<Guid>? ChildrenSteps { get; set; } = [];
     public Func<object?, bool>? Condition { get; set; } = (_) => true;
     public (string, Func<object?, bool>)? WaitFor { get; set; }
-    public bool ShouldRun()
+    public bool ShouldRun(object? input)
     {
-        return Condition is not null && Condition(null);
+        return Condition is not null && Condition(input);
     }
 }

--- a/src/GvatarWorkflow/Entities/WorkflowOptions.cs
+++ b/src/GvatarWorkflow/Entities/WorkflowOptions.cs
@@ -1,7 +1,6 @@
 ﻿using GvatarWorkflow.Entities.Interfaces;
 using GvatarWorkflow.Providers;
 using GvatarWorkflow.Providers.Interfaces;
-using GvatarWorkflow.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GvatarWorkflow.Entities;
@@ -10,7 +9,7 @@ public class WorkflowOptions(IServiceCollection services) : IWorkflowOptions
 {
     public Func<IServiceProvider, IPersistenceProvider> PersistenceFactory = new(serviceProvider => new InMemoryPersistenceProvider(serviceProvider.GetService<SingletonInMemoryPersistenceProvider>() ?? throw new Exception("Workflow PersistenceProvider is required.")));
     public Func<IServiceProvider, IWorkflowEventStore> EventStoreFactory = new(serviceProvider => new InMemoryWorkflowEventStore(serviceProvider.GetService<SingletonInMemoryWorkflowEventStore>() ?? throw new Exception("Workflow EventStore is required.")));
-    public Func<IServiceProvider, IQueueProvider> QueueFactory = new(serviceProvider => new InMemoryQueueProvider(serviceProvider.GetService<IWorkflowExecutor>() ?? throw new Exception("Workflow Executor is required.")));
+    public Func<IServiceProvider, IQueueProvider> QueueFactory = new(serviceProvider => new InMemoryQueueProvider(serviceProvider.GetService<IServiceScopeFactory>() ?? throw new Exception("ServiceScopeFactory is required.")));
 
     public IServiceCollection Services { get; set; } = services;
 

--- a/src/GvatarWorkflow/Providers/SingletonInMemoryPersistenceProvider.cs
+++ b/src/GvatarWorkflow/Providers/SingletonInMemoryPersistenceProvider.cs
@@ -21,7 +21,7 @@ public class SingletonInMemoryPersistenceProvider : IPersistenceProvider
                 CurrentStepObjectContext = input
             };
             _instances.Add(newWorkflowInstance);
-            return newGuid;
+            return Task.FromResult(newGuid);
         }
     }
 

--- a/src/GvatarWorkflow/Services/WorkflowExecutor.cs
+++ b/src/GvatarWorkflow/Services/WorkflowExecutor.cs
@@ -3,6 +3,7 @@ using GvatarWorkflow.Entities;
 using GvatarWorkflow.Providers.Interfaces;
 using GvatarWorkflow.Services.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 
 namespace GvatarWorkflow.Services;
 
@@ -19,27 +20,45 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, IWorkflo
         currentWorkflowInstance.Status = "In Progress";
         await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
 
+        SemaphoreSlim updateLock = new(1, 1);
+
         while (currentWorkflowInstance.NextPendingStepIds.Count > 0)
         {
             List<Step> currentStepsToExecute = currentWorkflowInstance.WorkflowDefinition.Steps
                 .Where(step => currentWorkflowInstance.NextPendingStepIds.Contains(step.Id))
                 .ToList();
 
+            object? inputSnapshot = currentWorkflowInstance.CurrentStepObjectContext;
+
             foreach (Step step in currentStepsToExecute)
             {
-                ActivityInstance? activityInstance = currentWorkflowInstance.ActivityInstances
-                    .FirstOrDefault(instance => instance.StepId == step.Id && instance.Status == "Waiting");
+                await updateLock.WaitAsync();
+                ActivityInstance? activityInstance;
+                try
+                {
+                    activityInstance = currentWorkflowInstance.ActivityInstances
+                        .FirstOrDefault(instance => instance.StepId == step.Id && instance.Status == "Waiting");
+
+                    if (activityInstance is null)
+                    {
+                        activityInstance = new ActivityInstance(step.Id, step.Name)
+                        {
+                            Status = "In Progress",
+                            StartedAtUtc = DateTimeOffset.UtcNow,
+                            Attempt = 1
+                        };
+                        currentWorkflowInstance.ActivityInstances.Add(activityInstance);
+                        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                    }
+                }
+                finally
+                {
+                    updateLock.Release();
+                }
 
                 if (activityInstance is null)
                 {
-                    activityInstance = new ActivityInstance(step.Id, step.Name)
-                    {
-                        Status = "In Progress",
-                        StartedAtUtc = DateTimeOffset.UtcNow,
-                        Attempt = 1
-                    };
-                    currentWorkflowInstance.ActivityInstances.Add(activityInstance);
-                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                    throw new InvalidOperationException($"Activity instance for step '{step.Name}' was not created.");
                 }
 
                 if (step.WaitFor is not null)
@@ -65,49 +84,54 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, IWorkflo
                     WorkflowEventRecord? matchingEvent = await _workflowEventStore.FindMatchingEvent(eventName, wait.CorrelationKeys);
                     if (matchingEvent is null)
                     {
-                        currentWorkflowInstance.Status = "Waiting";
-                        activityInstance.Status = "Waiting";
-                        activityInstance.WaitingForEvent = eventName;
-                        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                        await updateLock.WaitAsync();
+                        try
+                        {
+                            currentWorkflowInstance.Status = "Waiting";
+                            activityInstance.Status = "Waiting";
+                            activityInstance.WaitingForEvent = eventName;
+                            await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                        }
+                        finally
+                        {
+                            updateLock.Release();
+                        }
                         return;
                     }
 
                     await _workflowEventStore.RemoveEvent(matchingEvent.Id);
                     await _workflowEventStore.RemoveWait(wait.Id);
-                    activityInstance.Status = "In Progress";
-                    activityInstance.WaitingForEvent = null;
-                    step.WaitFor.Value.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
-                    currentWorkflowInstance.Status = "In Progress";
-                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
-                }
-
-                try
-                {
-                    var output = _delegateContext.InvokeDelegate(step.FunctionDelegateName, currentWorkflowInstance.CurrentStepObjectContext, step.Condition);
-                    currentWorkflowInstance.CurrentStepObjectContext = output;
-                    currentWorkflowInstance.PreviousCompletedStepIds.Add(step.Id);
-                    currentWorkflowInstance.NextPendingStepIds.Remove(step.Id);
-                    activityInstance.Output = output;
-                    activityInstance.Status = "Completed";
-                    activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
-
-                    if (step.ChildrenSteps is not null)
+                    await updateLock.WaitAsync();
+                    try
                     {
-                        currentWorkflowInstance.NextPendingStepIds.AddRange(step.ChildrenSteps);
-                        currentWorkflowInstance.NextPendingStepIds = currentWorkflowInstance.NextPendingStepIds.Distinct().ToList();
+                        activityInstance.Status = "In Progress";
+                        activityInstance.WaitingForEvent = null;
+                        step.WaitFor.Value.Item2.Invoke(currentWorkflowInstance.CurrentStepObjectContext);
+                        currentWorkflowInstance.Status = "In Progress";
+                        await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+                    }
+                    finally
+                    {
+                        updateLock.Release();
                     }
                 }
-                catch (Exception ex)
-                {
-                    activityInstance.Status = "Failed";
-                    activityInstance.ErrorMessage = ex.Message;
-                    activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
-                    currentWorkflowInstance.Status = "Failed";
-                    await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
-                    throw;
-                }
+            }
 
+            Task<object?>[] stepTasks = currentStepsToExecute
+                .Select(step => ExecuteStepAsync(step, inputSnapshot, currentWorkflowInstance, updateLock))
+                .ToArray();
+
+            object?[] outputs = await Task.WhenAll(stepTasks);
+
+            await updateLock.WaitAsync();
+            try
+            {
+                currentWorkflowInstance.CurrentStepObjectContext = outputs.Length == 1 ? outputs[0] : outputs.ToList();
                 await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+            }
+            finally
+            {
+                updateLock.Release();
             }
         }
 
@@ -136,5 +160,62 @@ public class WorkflowExecutor(IPersistenceProvider persistenceProvider, IWorkflo
     private static IReadOnlyCollection<WorkflowEventKey> BuildCorrelationKeys(WorkflowInstance workflowInstance)
     {
         return [new WorkflowEventKey("workflowInstanceId", workflowInstance.Id.ToString())];
+    }
+
+    private async Task<object?> ExecuteStepAsync(
+        Step step,
+        object? inputSnapshot,
+        WorkflowInstance currentWorkflowInstance,
+        SemaphoreSlim updateLock)
+    {
+        ActivityInstance activityInstance = currentWorkflowInstance.ActivityInstances
+            .First(instance => instance.StepId == step.Id && instance.Status != "Waiting");
+
+        object? output;
+
+        try
+        {
+            output = _delegateContext.InvokeDelegate(step.FunctionDelegateName, inputSnapshot, step.Condition);
+        }
+        catch (Exception ex)
+        {
+            await updateLock.WaitAsync();
+            try
+            {
+                activityInstance.Status = "Failed";
+                activityInstance.ErrorMessage = ex.Message;
+                activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
+                currentWorkflowInstance.Status = "Failed";
+                await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+            }
+            finally
+            {
+                updateLock.Release();
+            }
+            throw;
+        }
+
+        await updateLock.WaitAsync();
+        try
+        {
+            currentWorkflowInstance.PreviousCompletedStepIds.Add(step.Id);
+            currentWorkflowInstance.NextPendingStepIds.Remove(step.Id);
+            activityInstance.Output = output;
+            activityInstance.Status = "Completed";
+            activityInstance.CompletedAtUtc = DateTimeOffset.UtcNow;
+
+            if (step.ChildrenSteps is not null)
+            {
+                currentWorkflowInstance.NextPendingStepIds.AddRange(step.ChildrenSteps);
+                currentWorkflowInstance.NextPendingStepIds = currentWorkflowInstance.NextPendingStepIds.Distinct().ToList();
+            }
+
+            await _persistenceProvider.PersistWorkflowInstance(currentWorkflowInstance);
+        }
+        finally
+        {
+            updateLock.Release();
+        }
+        return output;
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure step conditions can evaluate against the current input by making `ShouldRun` input-aware.
- Provide clearer errors and guardrails when resolving and invoking delegates to avoid null/ambiguous behavior.
- Prevent race conditions and inconsistent persistence when executing sibling steps concurrently.
- Correct default dependency wiring for the queue provider and ensure async creation returns a `Task<Guid>`.

### Description
- Changed `IStep.ShouldRun` and `Step.ShouldRun` to accept `object? input` and use it when evaluating `Condition`.
- Hardened `DelegateContext.InvokeDelegate` with an initialization check, explicit delegate-not-found error, `FirstOrDefault` lookup, and safe instance creation before invoking `Execute`.
- Updated `WorkflowOptions.QueueFactory` to request `IServiceScopeFactory` instead of `IWorkflowExecutor` and removed an unused `using`.
- Overhauled `WorkflowExecutor.ExecuteWorkflowInstance` to use a `SemaphoreSlim` for protected state updates, create activity instances under the lock, handle `WaitFor` logic safely, execute sibling steps concurrently via `ExecuteStepAsync` + `Task.WhenAll`, and aggregate outputs into `CurrentStepObjectContext`.
- Fixed `SingletonInMemoryPersistenceProvider.CreateNewWorkflowInstance` to return `Task.FromResult(newGuid)` rather than a raw `Guid`.

### Testing
- No automated tests were executed in this environment because the .NET SDK was not available, so `dotnet test` was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4de905008332a1cef4a4873a98d7)